### PR TITLE
A11y and performance improvements

### DIFF
--- a/.nextra/layout.js
+++ b/.nextra/layout.js
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, useMemo, useContext, createContext } from 'react'
+import React, {
+  useState,
+  useEffect,
+  useMemo,
+  useContext,
+  createContext
+} from 'react'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
 import Link from 'next/link'
@@ -57,7 +63,7 @@ function Folder({ item, anchors }) {
       </button>
       <div
         style={{
-          display: open ? '' : 'none',
+          display: open ? '' : 'none'
         }}
       >
         <Menu dir={item.children} base={item.route} anchors={anchors} />
@@ -85,16 +91,14 @@ function File({ item, anchors }) {
             {anchors.map((anchor) => {
               const slug = slugify(anchor || '')
               return (
-                <a
-                  href={'#' + slug}
-                  key={`a-${slug}`}
-                  onClick={() => setMenu(false)}
-                >
-                  <span className="flex">
-                    <span className="mr-2 opacity-25">#</span>
-                    <span className="inline-block">{anchor}</span>
-                  </span>
-                </a>
+                <li key={`a-${slug}`}>
+                  <a href={'#' + slug} onClick={() => setMenu(false)}>
+                    <span className="flex">
+                      <span className="mr-2 opacity-25">#</span>
+                      <span className="inline-block">{anchor}</span>
+                    </span>
+                  </a>
+                </li>
               )
             })}
           </ul>
@@ -133,7 +137,7 @@ function Sidebar({ show, anchors }) {
       }`}
       style={{
         top: '4rem',
-        height: 'calc(100vh - 4rem)',
+        height: 'calc(100vh - 4rem)'
       }}
     >
       <div className="sidebar w-full p-4 pb-40 md:pb-16 h-full overflow-y-auto">
@@ -198,10 +202,11 @@ const Layout = ({ filename, full, title: _title, ssg = {}, children }) => {
     }
   }, [menu])
 
-  const currentIndex = useMemo(() => flatDirectories.findIndex(
-    (dir) => dir.route === pathname
-  ), [flatDirectories, pathname])
-  
+  const currentIndex = useMemo(
+    () => flatDirectories.findIndex((dir) => dir.route === pathname),
+    [flatDirectories, pathname]
+  )
+
   const title =
     flatDirectories[currentIndex]?.title ||
     titles.find((child) => child.props.mdxType === 'h1')?.props.children ||
@@ -232,13 +237,14 @@ const Layout = ({ filename, full, title: _title, ssg = {}, children }) => {
           </div>
 
           {/* {config.search && <Search directories={flatDirectories} />} */}
-          <DocSearch/>
+          <DocSearch />
 
           {config.github ? (
             <a
               className="text-current p-2 -mr-2"
               href={config.github}
               target="_blank"
+              aria-label="GitHub Repository"
             >
               <GitHubIcon height={28} />
             </a>
@@ -268,30 +274,32 @@ const Layout = ({ filename, full, title: _title, ssg = {}, children }) => {
             <Sidebar show={menu} anchors={anchors} />
           </MenuContext.Provider>
           <SSGContext.Provider value={ssg}>
-            {
-              full
-                ? <content className="relative pt-16 w-full overflow-x-hidden">{children}</content>
-                : <content className="relative pt-20 pb-16 px-6 md:px-8 w-full max-w-full overflow-x-hidden">
-                    <main className="max-w-screen-md">
-                      <Theme>{children}</Theme>
-                      <footer className="mt-24">
-                        <nav className="flex flex-row items-center justify-between">
-                          <div>
-                            <PrevLink currentIndex={currentIndex} />
-                          </div>
+            {full ? (
+              <content className="relative pt-16 w-full overflow-x-hidden">
+                {children}
+              </content>
+            ) : (
+              <content className="relative pt-20 pb-16 px-6 md:px-8 w-full max-w-full overflow-x-hidden">
+                <main className="max-w-screen-md">
+                  <Theme>{children}</Theme>
+                  <footer className="mt-24">
+                    <nav className="flex flex-row items-center justify-between">
+                      <div>
+                        <PrevLink currentIndex={currentIndex} />
+                      </div>
 
-                          <div>
-                            <NextLink currentIndex={currentIndex} />
-                          </div>
-                        </nav>
+                      <div>
+                        <NextLink currentIndex={currentIndex} />
+                      </div>
+                    </nav>
 
-                        <hr />
+                    <hr />
 
-                        {config.footer ? config.footer(props) : null}
-                      </footer>
-                    </main>
-                  </content>
-            }
+                    {config.footer ? config.footer(props) : null}
+                  </footer>
+                </main>
+              </content>
+            )}
           </SSGContext.Provider>
         </div>
       </div>
@@ -299,6 +307,6 @@ const Layout = ({ filename, full, title: _title, ssg = {}, children }) => {
   )
 }
 
-export default filename => {
-  return props => <Layout filename={filename} {...props}/>
+export default (filename) => {
+  return (props) => <Layout filename={filename} {...props} />
 }

--- a/.nextra/layout.js
+++ b/.nextra/layout.js
@@ -51,7 +51,12 @@ function Folder({ item, anchors }) {
   }, [active])
 
   return (
-    <li className={cn(open ? 'active' : '', { 'active-route': active })}>
+    <li
+      className={cn('focus:shadow-outline', {
+        'active-route': active,
+        active: open
+      })}
+    >
       <button
         onClick={() => {
           if (active) return

--- a/.nextra/layout.js
+++ b/.nextra/layout.js
@@ -53,7 +53,7 @@ function Folder({ item, anchors }) {
 
   return (
     <li
-      className={cn('focus:shadow-outline', {
+      className={cn({
         'active-route': active,
         active: open
       })}
@@ -64,6 +64,7 @@ function Folder({ item, anchors }) {
           TreeState[item.route] = !open
           render((x) => !x)
         }}
+        className="focus:shadow-outline"
       >
         {item.title}
       </button>
@@ -98,7 +99,11 @@ function File({ item, anchors }) {
               const slug = slugify(anchor || '')
               return (
                 <li key={`a-${slug}`}>
-                  <a href={'#' + slug} onClick={() => setMenu(false)}>
+                  <a
+                    href={'#' + slug}
+                    onClick={() => setMenu(false)}
+                    className="focus:shadow-outline"
+                  >
                     <span className="flex">
                       <span className="mr-2 opacity-25">#</span>
                       <span className="inline-block">{anchor}</span>
@@ -116,7 +121,7 @@ function File({ item, anchors }) {
   return (
     <li className={active ? 'active' : ''}>
       <Link href={item.route}>
-        <a onClick={() => setMenu(false)}>{title}</a>
+        <a onClick={() => setMenu(false)} className="focus:shadow-outline">{title}</a>
       </Link>
     </li>
   )

--- a/.nextra/layout.js
+++ b/.nextra/layout.js
@@ -11,6 +11,7 @@ import Link from 'next/link'
 import slugify from '@sindresorhus/slugify'
 import 'focus-visible'
 import cn from 'classnames'
+import { SkipNavContent } from '@reach/skip-nav'
 
 import Theme from './theme'
 import SSGContext from './ssg'
@@ -285,26 +286,29 @@ const Layout = ({ filename, full, title: _title, ssg = {}, children }) => {
                 {children}
               </content>
             ) : (
-              <content className="relative pt-20 pb-16 px-6 md:px-8 w-full max-w-full overflow-x-hidden">
-                <main className="max-w-screen-md">
-                  <Theme>{children}</Theme>
-                  <footer className="mt-24">
-                    <nav className="flex flex-row items-center justify-between">
-                      <div>
-                        <PrevLink currentIndex={currentIndex} />
-                      </div>
+              <>
+                <SkipNavContent />
+                <content className="relative pt-20 pb-16 px-6 md:px-8 w-full max-w-full overflow-x-hidden">
+                  <main className="max-w-screen-md">
+                    <Theme>{children}</Theme>
+                    <footer className="mt-24">
+                      <nav className="flex flex-row items-center justify-between">
+                        <div>
+                          <PrevLink currentIndex={currentIndex} />
+                        </div>
 
-                      <div>
-                        <NextLink currentIndex={currentIndex} />
-                      </div>
-                    </nav>
+                        <div>
+                          <NextLink currentIndex={currentIndex} />
+                        </div>
+                      </nav>
 
-                    <hr />
+                      <hr />
 
-                    {config.footer ? config.footer(props) : null}
-                  </footer>
-                </main>
-              </content>
+                      {config.footer ? config.footer(props) : null}
+                    </footer>
+                  </main>
+                </content>
+              </>
             )}
           </SSGContext.Provider>
         </div>

--- a/.nextra/layout.js
+++ b/.nextra/layout.js
@@ -244,6 +244,7 @@ const Layout = ({ filename, full, title: _title, ssg = {}, children }) => {
               className="text-current p-2 -mr-2"
               href={config.github}
               target="_blank"
+              rel="noopener"
               aria-label="GitHub Repository"
             >
               <GitHubIcon height={28} />

--- a/.nextra/search.js
+++ b/.nextra/search.js
@@ -111,6 +111,7 @@ const Search = ({ directories }) => {
         onKeyDown={handleKeyDown}
         onFocus={() => setShow(true)}
         ref={input}
+        aria-label="Search documentation"
       />
       {renderList && (
         <ul className="shadow-md list-none p-0 m-0 absolute left-0 md:right-0 bg-white rounded mt-1 border top-100 divide-y divide-gray-300 z-2">

--- a/.nextra/styles.css
+++ b/.nextra/styles.css
@@ -125,7 +125,8 @@ content li {
   width: 1px;
 }
 
-.subheading-anchor + a:hover .anchor-icon {
+.subheading-anchor + a:hover .anchor-icon,
+.subheading-anchor + a:focus .anchor-icon {
   opacity: 1;
 }
 .anchor-icon {

--- a/.nextra/styles.css
+++ b/.nextra/styles.css
@@ -1,6 +1,5 @@
 @tailwind base;
 
-@import url('https://rsms.me/inter/inter.css');
 html {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
 }

--- a/.nextra/styles.css
+++ b/.nextra/styles.css
@@ -1,11 +1,15 @@
 @tailwind base;
 
 html {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
 }
 @supports (font-variation-settings: normal) {
   html {
-    font-family: 'Inter var', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+    font-family: 'Inter var', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+      'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+      'Helvetica Neue', sans-serif;
   }
 }
 
@@ -89,18 +93,21 @@ figure figcaption {
 .sidebar ul ul {
   @apply ml-5;
 }
-.sidebar a:focus-visible, .sidebar button:focus-visible {
+.sidebar a:focus-visible,
+.sidebar button:focus-visible {
   @apply shadow-outline;
 }
 .sidebar li.active > a {
   @apply font-semibold text-black bg-gray-200;
 }
-.sidebar button, .sidebar a {
+.sidebar button,
+.sidebar a {
   @apply block w-full text-left text-base text-black no-underline text-gray-600 mt-1 p-2 rounded select-none outline-none;
   -webkit-tap-highlight-color: transparent;
   -webkit-touch-callout: none;
 }
-.sidebar a:hover, .sidebar button:hover {
+.sidebar a:hover,
+.sidebar button:hover {
   @apply text-gray-900 bg-gray-100;
 }
 
@@ -159,4 +166,12 @@ input[type='search']::-webkit-search-results-decoration {
   width: 500px;
   min-width: 300px;
   max-width: calc(100vw - 50px);
+}
+
+[data-reach-skip-link] {
+  @apply sr-only;
+}
+
+[data-reach-skip-link]:focus {
+  @apply not-sr-only fixed ml-6 top-0 bg-white text-lg px-6 py-2 mt-2 outline-none shadow-outline z-50;
 }

--- a/.nextra/theme.js
+++ b/.nextra/theme.js
@@ -122,7 +122,7 @@ const A = ({ children, ...props }) => {
   const isExternal = props.href?.startsWith('https://')
   if (isExternal) {
     return (
-      <a target="_blank" {...props}>
+      <a target="_blank" rel="noopener" {...props}>
         {children}
       </a>
     )

--- a/nextra.config.js
+++ b/nextra.config.js
@@ -72,7 +72,7 @@ export default {
       content="https://assets.vercel.com/image/upload/v1572282926/swr/twitter-card.jpg"
     />
     <meta name="apple-mobile-web-app-title" content="SWR" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" media="print" onload="this.media='all'" />
   </>,
   footer: ({ filepath }) => <>
     <div className="mt-24 flex justify-between flex-col-reverse md:flex-row items-center md:items-end">

--- a/nextra.config.js
+++ b/nextra.config.js
@@ -76,13 +76,13 @@ export default {
   </>,
   footer: ({ filepath }) => <>
     <div className="mt-24 flex justify-between flex-col-reverse md:flex-row items-center md:items-end">
-      <a href="https://vercel.com/?utm_source=swr" target="_blank" className="inline-flex items-center no-underline text-current font-semibold">
+      <a href="https://vercel.com/?utm_source=swr" target="_blank" rel="noopener" className="inline-flex items-center no-underline text-current font-semibold">
         <span className="mr-1">Powered by</span><span><Vercel/></span>
       </a>
       <div className="mt-6"/>
       <a className="text-sm" href={
         'https://github.com/vercel/swr-site/tree/master/pages' + filepath
-      } target="_blank">Edit this page on GitHub</a>
+      } target="_blank" rel="noopener">Edit this page on GitHub</a>
     </div>
   </>
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "Shu Ding",
   "license": "MIT",
   "dependencies": {
+    "@reach/skip-nav": "^0.10.5",
     "@sindresorhus/slugify": "^1.0.0",
     "classnames": "^2.2.6",
     "focus-visible": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "markdown-to-jsx": "^6.11.4",
     "match-sorter": "^4.1.0",
     "next": "^9.4.4",
+    "next-google-fonts": "^1.1.0",
     "prism-react-renderer": "^1.1.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,8 +1,15 @@
 import '.nextra/styles.css'
+import GoogleFonts from 'next-google-fonts'
 
 export default function Nextra({ Component, pageProps }) {
-  return <>
-    <Component {...pageProps} />
-    <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"/>
-  </>
+  return (
+    <>
+      <GoogleFonts
+        href="https://fonts.googleapis.com/css2?family=Inter&display=swap"
+        rel="stylesheet"
+      />
+      <Component {...pageProps} />
+      <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js" />
+    </>
+  )
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -9,11 +9,6 @@ export default function Nextra({ Component, pageProps }) {
         rel="stylesheet"
       />
       <Component {...pageProps} />
-      <script
-        src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
-        async
-        defer
-      />
     </>
   )
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -9,7 +9,11 @@ export default function Nextra({ Component, pageProps }) {
         rel="stylesheet"
       />
       <Component {...pageProps} />
-      <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js" />
+      <script
+        src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
+        async
+        defer
+      />
     </>
   )
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html lang="en">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,11 +1,13 @@
 import React from 'react'
 import Document, { Html, Head, Main, NextScript } from 'next/document'
+import { SkipNavLink } from '@reach/skip-nav'
 
 class MyDocument extends Document {
   render() {
     return (
       <Html lang="en">
         <Head />
+        <SkipNavLink />
         <body>
           <Main />
           <NextScript />

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -9,6 +9,11 @@ class MyDocument extends Document {
         <body>
           <Main />
           <NextScript />
+          <script
+            src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
+            async
+            defer
+          />
         </body>
       </Html>
     )

--- a/pages/change-log.mdx
+++ b/pages/change-log.mdx
@@ -13,7 +13,7 @@ export const getStaticProps = ({ params }) => {
 export const ReleasesRenderer = () => {
   const releases = useSSG()
   return <Markdown>{releases.map(release => {
-    return `## <a href="${release.html_url}" target="_blank">${release.tag_name}</a>\n\nPublished on ${new Date(release.published_at) .toDateString()}.\n\n${release.body}`
+    return `## <a href="${release.html_url}" target="_blank" rel="noopener">${release.tag_name}</a>\n\nPublished on ${new Date(release.published_at) .toDateString()}.\n\n${release.body}`
   }).join('\n\n')}</Markdown>
 }
 

--- a/pages/docs/data-fetching.mdx
+++ b/pages/docs/data-fetching.mdx
@@ -7,7 +7,7 @@ import Link from 'next/link'
 { data, error } = useSWR(key, fetcher)
 ```
 
-This is the very fundamental API of SWR. The `fetcher` here is an async function that **accepts the `key`** of SWR, and returns the data. 
+This is the very fundamental API of SWR. The `fetcher` here is an async function that **accepts the `key`** of SWR, and returns the data.
 
 The returned value will be passed as `data`, and if it throws, it will be caught as `error`.
 
@@ -34,7 +34,7 @@ function App () {
 <Callout emoji="💡">
   If you are using <strong>Next.js</strong>, you don't need to import this polyfill:
   <br/>
-  <a target="_blank" href="https://nextjs.org/blog/next-9-1-7#new-built-in-polyfills-fetch-url-and-objectassign">New Built-In Polyfills: fetch(), URL, and Object.assign</a>
+  <a target="_blank" rel="noopener" href="https://nextjs.org/blog/next-9-1-7#new-built-in-polyfills-fetch-url-and-objectassign">New Built-In Polyfills: fetch(), URL, and Object.assign</a>
 </Callout>
 
 ## Axios

--- a/pages/docs/pagination.mdx
+++ b/pages/docs/pagination.mdx
@@ -3,5 +3,5 @@ import Callout from 'components/callout'
 # Pagination
 
 <Callout emoji="🚨" background="bg-red-200">
-  The pagination API is still experimental. For more information, please read <a href="https://github.com/vercel/swr/pull/435" target="_blank">this PR</a>.
+  The pagination API is still experimental. For more information, please read <a href="https://github.com/vercel/swr/pull/435" target="_blank" rel="noopener">this PR</a>.
 </Callout>

--- a/pages/docs/suspense.mdx
+++ b/pages/docs/suspense.mdx
@@ -3,9 +3,9 @@ import Callout from 'components/callout'
 # Suspense
 
 <Callout emoji="🚨" background="bg-red-200">
-  Suspense is current an <strong>experimental</strong> feature of React. These APIs may change significantly and without a warning before they become a part of React. 
+  Suspense is current an <strong>experimental</strong> feature of React. These APIs may change significantly and without a warning before they become a part of React.
   <br/>
-  <a href="https://reactjs.org/docs/concurrent-mode-suspense.html" target="_blank">More information</a>
+  <a href="https://reactjs.org/docs/concurrent-mode-suspense.html" target="_blank" rel="noopener">More information</a>
 </Callout>
 
 <Callout>
@@ -32,7 +32,7 @@ function App () {
 }
 ```
 
-In Suspense mode, `data` is always the fetch response (so you don't need to check if it's `undefined`). 
+In Suspense mode, `data` is always the fetch response (so you don't need to check if it's `undefined`).
 But if an error occurred, you need to use an [error boundary](https://reactjs.org/docs/concurrent-mode-suspense.html#handling-errors) to catch it:
 
 ```jsx

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,6 +1112,23 @@
   resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-9.4.4.tgz#d94cbb3b354a07f1f5b80e554d6b9e34aba99e41"
   integrity sha512-9nKENeWRI6kQk44TbeqleIVtNLfcS3klVUepzl/ZCqzR5Bi06uqBCD277hdVvG/wL1pxA+R/pgJQLqnF5E2wPQ==
 
+"@reach/skip-nav@^0.10.5":
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/@reach/skip-nav/-/skip-nav-0.10.5.tgz#83da28bcfd3ba0af05c7e82b0a5e2d4a0a0c6581"
+  integrity sha512-Cg/nGKmu73jdSf46J53Qs+tUat7UVH6zQfq0VYdBw+Xqg72U1mkN2NyMAvb3N8O0cc3nDGvZoq0MKWrC7+TeqQ==
+  dependencies:
+    "@reach/utils" "0.10.5"
+    tslib "^2.0.0"
+
+"@reach/utils@0.10.5":
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.10.5.tgz#fbac944d29565f6dd7abd0e1b13950e99b1e470b"
+  integrity sha512-5E/xxQnUbmpI/LrufBAOXjunl96DnqX6B4zC2MO2KH/dRzLug5gM5VuOwV26egsp0jvsSPxojwciOhS43px3qw==
+  dependencies:
+    "@types/warning" "^3.0.0"
+    tslib "^2.0.0"
+    warning "^4.0.3"
+
 "@sindresorhus/slugify@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/slugify/-/slugify-1.0.0.tgz#db6a4df1935cf6c331303ce82021df361ff52348"
@@ -1159,6 +1176,11 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
+
+"@types/warning@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
+  integrity sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI=
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -6626,6 +6648,11 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
+tslib@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -6908,6 +6935,13 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+warning@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack-chokidar2@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4281,6 +4281,11 @@ neo-async@2.6.1, neo-async@^2.5.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
+next-google-fonts@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/next-google-fonts/-/next-google-fonts-1.1.0.tgz#845fb024994f219fd3bdf940b0a6890c0e090ce4"
+  integrity sha512-EpgqiJkpb93k+bprZo4HDsS1yCXBS4imyysQOjtDvAt1eUWZUWcXdbevrNte7V43GQrDL1Gkmeg2rut9anlOYw==
+
 next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"


### PR DESCRIPTION
- Fix a11y score on lighthouse
- use `next-google-fonts` to asynchronously load Inter
- Fix best practices score on lighthouse
- Defer/async the docsearch CSS and JS. Since the search is opened after first interaction, it can be delayed
- Add focus styles to sidebar, improve focus style of header links
- Add skip-nav to jump to main content

Todo:
- [ ] ~Figure out why skip-nav isn't re-focused when pressing [tab] from document.body focus~ nvm, this is Gatsby behavior

Before:

<img width="315" alt="Screen Shot 2020-07-07 at 6 21 38 PM" src="https://user-images.githubusercontent.com/34928425/86858864-ba2ac980-c07e-11ea-9022-f4ba8a5a2f7a.png">

After:

<img width="322" alt="Screen Shot 2020-07-07 at 6 21 18 PM" src="https://user-images.githubusercontent.com/34928425/86858869-bbf48d00-c07e-11ea-9836-00affbb0925c.png">
