### PR TITLE
Add docs and example for useSWRInfinite

### DIFF
--- a/.nextra/docsearch.js
+++ b/.nextra/docsearch.js
@@ -32,7 +32,7 @@ export default function () {
     }
   }, [])
 
-  return <div className="relative w-full md:w-64 mr-2">
+  return <div className="relative w-full md:w-64 mr-2 docs-search">
     <input
       id="algolia-doc-search"
       className="appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline w-full"

--- a/.nextra/styles.css
+++ b/.nextra/styles.css
@@ -162,6 +162,10 @@ input[type='search']::-webkit-search-results-decoration {
   right: 0;
 }
 
+.docs-search > span {
+  width: 100%;
+}
+
 .algolia-autocomplete .algolia-docsearch-suggestion--category-header span {
   display: inline-block;
 }

--- a/pages/docs/meta.json
+++ b/pages/docs/meta.json
@@ -6,6 +6,7 @@
   "conditional-fetching": "Conditional Data Fetching",
   "arguments": "Arguments",
   "mutation": "Mutation",
+  "pagination": "Pagination",
   "prefetching": "Prefetching",
   "with-nextjs": "Usage with Next.js",
   "suspense": "Suspense"

--- a/pages/docs/pagination.mdx
+++ b/pages/docs/pagination.mdx
@@ -220,7 +220,7 @@ In infinite loading, one _page_ is one request, and our goal is to fetch multipl
 
 - `data`: an array of fetch response values of each page
 - `mutate`: same as `useSWR`'s bound mutate function but manipulates the data array
-- `size`: the number of pages _will_ be fetched and returned
+- `size`: the number of pages that _will_ be fetched and returned
 - `setSize`: set the number of pages that need to be fetched
 
 ### Example 1: Index Based Paginated API

--- a/pages/docs/pagination.mdx
+++ b/pages/docs/pagination.mdx
@@ -164,7 +164,7 @@ function App () {
 
 However, in some advanced use cases, the solution above doesn't work.
 
-For example, we are still implementing the "Load More" UI, but we also need to display a number 
+For example, we are still implementing the same "Load More" UI, but also need to display a number 
 about how many items are there in total. We can't use the `<Page />` solution anymore because
 the top level UI (`<App />`) needs the data inside each page:
 
@@ -188,11 +188,11 @@ function App () {
 Also, if the pagination API is **cursor based**, that solution doesn't work either. Because each page
 needs the data from the previous page, they're not isolated.
 
-That's why we introduced this new `useSWRInfinite` Hook.
+That's how this new `useSWRInfinite` Hook can help.
 
 ## useSWRInfinite
 
-`useSWRInfinite` gives us the ability to trigger dynamic number of requests with one Hook. This is how it looks:
+`useSWRInfinite` gives us the ability to trigger a number of requests with one Hook. This is how it looks:
 
 ```jsx
 const { data, error, isValidating, mutate, size, setSize } = useSWRInfinite(
@@ -200,7 +200,136 @@ const { data, error, isValidating, mutate, size, setSize } = useSWRInfinite(
 )
 ```
 
-Similar to `useSWR`, it accepts a function to get the key, a function to fetch the data, and an `options` object.
-Besides the `useSWR` return values, it also returns the page size and a function to set the size, like a React state.
+Similar to `useSWR`, this new Hook accepts a function that returns the request key, a fetcher function, and options.
+It returns all the values that `useSWR` returns, including 2 extra values: the page size and a page size setter, like a React state.
 
+In infinite loading, one _page_ is one request, and our goal is to fetch multiple pages and render them.
 
+### API
+
+#### Parameters
+
+- `getKey`: a function that accepts the index and the previous page data, returns the key of a page
+- `fetcher`: same as `useSWR`'s [fetcher function](/docs/data-fetching)
+- `options`: accepts all the options that `useSWR` supports, with 3 extra options:
+  - `initialSize = 1`: number of pages should be loaded initially
+  - `revalidateAll = false`: always try to revalidate all pages
+  - `persistSize = false`: don't reset the page size to 1 (or `initialSize` if set) when the first page's key changes
+
+#### Return Values
+
+- `data`: an array of fetch response values of each page
+- `mutate`: same as `useSWR`'s bound mutate function but manipulates the data array
+- `size`: the number of pages _will_ be fetched and returned
+- `setSize`: set the number of pages that need to be fetched
+
+### Example 1: Index Based Paginated API
+
+For normal index based APIs:
+
+```
+GET /users?page=0&limit=10
+[
+  { name: 'Alice', ... },
+  { name: 'Bob', ... },
+  { name: 'Cathy', ... },
+  ...
+]
+```
+
+```jsx highlight=4,5,6,7,10
+// A function to get the SWR key of each page,
+// its return value will be accepted by `fetcher`.
+// If `null` is returned, the request of that page won't start.
+const getKey = (pageIndex, previousPageData) => {
+  if (previousPageData && !previousPageData.length) return null // reached the end
+  return `/users?page=${pageIndex}&limit=10`                    // SWR key
+}
+
+function App () {
+  const { data, size, setSize } = useSWRInfinite(getKey, fetcher)
+  if (!data) return 'loading'
+
+  // We can now calculate the number of all users
+  let totalUsers = 0
+  for (let i = 0; i < data.length; i++) {
+    totalUsers += data[i].length
+  }
+
+  return <div>
+    <p>{totalUsers} users listed</p>
+    {data.map((users, index) => {
+      // `data` is an array of each page's API response.
+      return users.map(user => <div key={user.id}>{user.name}</div>)
+    })}
+    <button onClick={() => setSize(size + 1)}>Load More</button>
+  </div>
+}
+```
+
+The `getKey` function is the major difference between `useSWRInfinite` and `useSWR`. 
+It accepts the index of the current page, as well as the data from the previous page.
+So both index based and cursor based pagination API can be supported nicely.
+
+Also `data` is no longer just one API response. It's an array of multiple API responses:
+
+```js
+// `data` will look like this
+[
+  [
+    { name: 'Alice', ... },
+    { name: 'Bob', ... },
+    { name: 'Cathy', ... },
+    ...
+  ],
+  [
+    { name: 'John', ... },
+    { name: 'Paul', ... },
+    { name: 'George', ... },
+    ...
+  ],
+  ...
+]
+```
+
+### Example 2: Cursor or Offset Based Paginated API
+
+Let's say the API now requires a cursor and returns the next cursor alongside with the data:
+
+```
+GET /users?cursor=123&limit=10
+{
+  data: [
+    { name: 'Alice' },
+    { name: 'Bob' },
+    { name: 'Cathy' },
+    ...
+  ],
+  nextCursor: 456
+}
+```
+
+We can change our `getKey` function to:
+
+```jsx
+const getKey = (pageIndex, previousPageData) => {
+  // reached the end
+  if (previousPageData && !previousPageData.data) return null
+
+  // first page, we don't have `previousPageData`
+  if (pageIndex === 0) return `/users?limit=10`
+
+  // add the cursor to the API endpoint
+  return `/users?cursor=${previousPageData.nextCursor}&limit=10`
+}
+```
+
+### Advanced Features
+
+[Here is an example](/examples/infinite-loading) showing how you can implement the following features with `useSWRInfinite`:
+
+- loading states
+- show a special UI if it's empty
+- disable the "Load More" button if reached the end
+- changeable data source
+- refresh the entire list

--- a/pages/docs/pagination.mdx
+++ b/pages/docs/pagination.mdx
@@ -2,6 +2,205 @@ import Callout from 'components/callout'
 
 # Pagination
 
-<Callout emoji="🚨" background="bg-red-200">
-  The pagination API is still experimental. For more information, please read <a href="https://github.com/vercel/swr/pull/435" target="_blank" rel="noopener">this PR</a>.
+<Callout emoji="✅">
+  Please update to the latest version (≥ 0.3.0) to use this API. The previous <code>useSWRPages</code> API is now deprecated.
 </Callout>
+
+SWR provides a dedicated API `useSWRInfinite` to support common UI patterns such as **pagination** and **infinite loading**.
+
+## When Not to Use this API
+
+### Pagination
+
+First of all, we might **NOT** need this API if we are building something like this:
+
+<div className="mt-8" />
+
+<svg viewBox="0 0 769 356" fill="none">
+<path d="M5 0.5H763C765.485 0.5 767.5 2.51472 767.5 5V351C767.5 353.485 765.485 355.5 763 355.5H5.00002C2.51473 355.5 0.5 353.485 0.5 351V5C0.5 2.51472 2.51472 0.5 5 0.5Z" fill="white" stroke="#EEEEEE"/>
+<path d="M1 288H769" stroke="#E5E5E5"/>
+<path d="M21 26H747V40H21V26Z" fill="#E5E5E5"/>
+<path d="M21 70H747V84H21V70Z" fill="#E5E5E5"/>
+<path d="M21 114H747V128H21V114Z" fill="#E5E5E5"/>
+<path d="M21 158H747V172H21V158Z" fill="#E5E5E5"/>
+<path d="M21 202H747V216H21V202Z" fill="#E5E5E5"/>
+<path d="M21 246H747V260H21V246Z" fill="#E5E5E5"/>
+<rect x="21.5" y="306.5" width="69" height="31" rx="2.5" fill="#FAFAFA" stroke="#D3D3D3"/>
+<path d="M40.82 327.055L41.587 326.288L39.0259 323.736H45.7163V322.628H39.0259L41.587 320.067L40.82 319.308L36.9464 323.182L40.82 327.055ZM51.3455 327H52.6623V323.932H54.4521C56.4762 323.932 57.4776 322.709 57.4776 321.098C57.4776 319.491 56.4847 318.273 54.4563 318.273H51.3455V327ZM52.6623 322.815V319.402H54.3157C55.6197 319.402 56.1523 320.109 56.1523 321.098C56.1523 322.087 55.6197 322.815 54.3327 322.815H52.6623ZM58.919 327H60.1932V323.003C60.1932 322.146 60.8537 321.528 61.7571 321.528C62.0213 321.528 62.3196 321.575 62.4219 321.605V320.386C62.294 320.369 62.0426 320.357 61.8807 320.357C61.1136 320.357 60.4574 320.791 60.2188 321.494H60.1506V320.455H58.919V327ZM66.1112 327.132C67.5387 327.132 68.5487 326.429 68.8384 325.364L67.6325 325.146C67.4023 325.764 66.8484 326.08 66.1239 326.08C65.033 326.08 64.3001 325.372 64.266 324.111H68.9194V323.659C68.9194 321.294 67.5046 320.369 66.0217 320.369C64.1978 320.369 62.9961 321.759 62.9961 323.77C62.9961 325.803 64.1808 327.132 66.1112 327.132ZM64.2702 323.156C64.3214 322.227 64.9947 321.422 66.0302 321.422C67.0188 321.422 67.6665 322.155 67.6708 323.156H64.2702ZM75.8974 320.455H74.5295L72.8761 325.491H72.8079L71.1502 320.455H69.7823L72.1602 327H73.5238L75.8974 320.455Z" fill="#454545"/>
+<rect x="307.5" y="306.5" width="69" height="31" rx="2.5" fill="#FAFAFA" stroke="#D3D3D3"/>
+<path d="M329.225 318.273H327.922V324.682H327.841L323.4 318.273H322.181V327H323.498V320.599H323.579L328.015 327H329.225V318.273ZM333.865 327.132C335.293 327.132 336.303 326.429 336.592 325.364L335.386 325.146C335.156 325.764 334.602 326.08 333.878 326.08C332.787 326.08 332.054 325.372 332.02 324.111H336.673V323.659C336.673 321.294 335.259 320.369 333.776 320.369C331.952 320.369 330.75 321.759 330.75 323.77C330.75 325.803 331.935 327.132 333.865 327.132ZM332.024 323.156C332.075 322.227 332.749 321.422 333.784 321.422C334.773 321.422 335.42 322.155 335.425 323.156H332.024ZM338.94 320.455H337.543L339.554 323.727L337.517 327H338.915L340.385 324.554L341.859 327H343.253L341.195 323.727L343.236 320.455H341.842L340.385 323.003L338.94 320.455ZM347.599 320.455H346.257V318.886H344.983V320.455H344.024V321.477H344.983V325.342C344.979 326.531 345.886 327.107 346.892 327.085C347.297 327.081 347.57 327.004 347.719 326.949L347.489 325.896C347.403 325.913 347.246 325.952 347.041 325.952C346.628 325.952 346.257 325.815 346.257 325.078V321.477H347.599V320.455ZM357.724 327.055L361.598 323.182L357.724 319.308L356.957 320.075L359.518 322.628H352.828V323.736H359.518L356.957 326.293L357.724 327.055Z" fill="#454545"/>
+<path d="M281.098 322.03C281.563 322.03 281.951 321.651 281.951 321.178C281.951 320.713 281.563 320.33 281.098 320.33C280.63 320.33 280.246 320.713 280.246 321.178C280.246 321.651 280.63 322.03 281.098 322.03ZM284.497 322.03C284.961 322.03 285.349 321.651 285.349 321.178C285.349 320.713 284.961 320.33 284.497 320.33C284.028 320.33 283.645 320.713 283.645 321.178C283.645 321.651 284.028 322.03 284.497 322.03ZM287.895 322.03C288.36 322.03 288.748 321.651 288.748 321.178C288.748 320.713 288.36 320.33 287.895 320.33C287.426 320.33 287.043 320.713 287.043 321.178C287.043 321.651 287.426 322.03 287.895 322.03Z" fill="black"/>
+<rect x="103.5" y="306.5" width="44" height="31" rx="2.5" fill="#FAFAFA" stroke="#D3D3D3"/>
+<path d="M126.653 318.273H125.37L123.193 319.696V320.957L125.281 319.594H125.332V327H126.653V318.273Z" fill="#454545"/>
+<rect x="160.5" y="306.5" width="44" height="31" rx="2.5" fill="#EDEDED" stroke="#B3B3B3"/>
+<path d="M179.498 327H185.242V325.871H181.313V325.807L183.048 323.991C184.646 322.376 185.102 321.605 185.102 320.629C185.102 319.227 183.96 318.153 182.315 318.153C180.683 318.153 179.489 319.21 179.489 320.804H180.746C180.742 319.866 181.347 319.253 182.289 319.253C183.175 319.253 183.849 319.798 183.849 320.668C183.849 321.439 183.389 321.993 182.451 322.986L179.498 326.045V327Z" fill="#454545"/>
+<rect x="217.5" y="306.5" width="44" height="31" rx="2.5" fill="#FAFAFA" stroke="#D3D3D3"/>
+<path d="M239.349 327.119C241.13 327.119 242.438 326.054 242.434 324.605C242.438 323.501 241.769 322.709 240.61 322.53V322.462C241.522 322.227 242.114 321.511 242.11 320.531C242.114 319.249 241.062 318.153 239.383 318.153C237.781 318.153 236.494 319.121 236.451 320.54H237.725C237.755 319.739 238.509 319.253 239.366 319.253C240.256 319.253 240.84 319.794 240.836 320.599C240.84 321.443 240.163 321.997 239.195 321.997H238.458V323.071H239.195C240.406 323.071 241.104 323.685 241.104 324.562C241.104 325.411 240.367 325.986 239.34 325.986C238.394 325.986 237.657 325.5 237.606 324.724H236.268C236.323 326.148 237.585 327.119 239.349 327.119Z" fill="#454545"/>
+</svg>
+
+...which is a typical pagination UI. Let's see how it can be easily implemented with the exsiting
+`useSWR`:
+
+```jsx highlight=5
+function App () {
+  const [pageIndex, setPageIndex] = useState(0);
+
+  // The API URL includes the page index, which is a React state.
+  const { data } = useSWR(`/api/data?page=${pageIndex}`, fetcher);
+
+  // ... handle loading and error states
+
+  return <div>
+    {data.map(item => <div key={item.id}>{item.name}</div>)}
+    <button onClick={() => setPageIndex(pageIndex - 1)}>Previous</button>
+    <button onClick={() => setPageIndex(pageIndex + 1)}>Next</button>
+  </div>
+}
+```
+
+Furthermore, we can create an abstraction for this "page component":
+
+```jsx highlight=13
+function Page ({ index }) {
+  const { data } = useSWR(`/api/data?page=${index}`, fetcher);
+
+  // ... handle loading and error states
+
+  return data.map(item => <div key={item.id}>{item.name}</div>)
+}
+
+function App () {
+  const [pageIndex, setPageIndex] = useState(0);
+
+  return <div>
+    <Page index={pageIndex}/>
+    <button onClick={() => setPageIndex(pageIndex - 1)}>Previous</button>
+    <button onClick={() => setPageIndex(pageIndex + 1)}>Next</button>
+  </div>
+}
+```
+
+Because of SWR's cache, we get the benefit to preload the next page. We render the next page inside
+a hidden div, so SWR will trigger the data fetching of the next page. When the user navigates to the next page, the data is already there:
+
+```jsx highlight=6
+function App () {
+  const [pageIndex, setPageIndex] = useState(0);
+
+  return <div>
+    <Page index={pageIndex}/>
+    <div style={{ display: 'none' }}><Page index={pageIndex + 1}/></div>
+    <button onClick={() => setPageIndex(pageIndex - 1)}>Previous</button>
+    <button onClick={() => setPageIndex(pageIndex + 1)}>Next</button>
+  </div>
+}
+```
+
+With just 1 line of code, we get a much better UX. The `useSWR` hook is so powerful,
+that most scenarios are covered by it.
+
+### Infinite Loading
+
+Sometimes we want to build an **infinite loading** UI, with a "Load More" button that appends data
+to the list (or done automatically when you scroll):
+
+<div className="mt-8" />
+
+<svg viewBox="0 0 769 356" fill="none">
+<path d="M5 0.5H763C765.485 0.5 767.5 2.51472 767.5 5V351C767.5 353.485 765.485 355.5 763 355.5H5.00002C2.51473 355.5 0.5 353.485 0.5 351V5C0.5 2.51472 2.51472 0.5 5 0.5Z" fill="white" stroke="#EEEEEE"/>
+<path d="M21 26H747V40H21V26Z" fill="#E5E5E5"/>
+<path d="M21 70H747V84H21V70Z" fill="#E5E5E5"/>
+<path d="M21 114H747V128H21V114Z" fill="#E5E5E5"/>
+<path d="M21 158H747V172H21V158Z" fill="#E5E5E5"/>
+<path d="M21 202H747V216H21V202Z" fill="#E5E5E5"/>
+<path d="M21 246H747V260H21V246Z" fill="#E5E5E5"/>
+<rect x="21.5" y="288.5" width="725" height="31" rx="2.5" fill="#FAFAFA" stroke="#D3D3D3"/>
+<path d="M354.49 309H359.761V307.866H355.807V300.273H354.49V309ZM363.918 309.132C365.763 309.132 366.969 307.781 366.969 305.757C366.969 303.72 365.763 302.369 363.918 302.369C362.073 302.369 360.867 303.72 360.867 305.757C360.867 307.781 362.073 309.132 363.918 309.132ZM363.923 308.062C362.717 308.062 362.154 307.01 362.154 305.753C362.154 304.5 362.717 303.435 363.923 303.435C365.12 303.435 365.683 304.5 365.683 305.753C365.683 307.01 365.12 308.062 363.923 308.062ZM370.297 309.145C371.379 309.145 371.988 308.595 372.231 308.105H372.282V309H373.527V304.653C373.527 302.749 372.027 302.369 370.987 302.369C369.802 302.369 368.711 302.847 368.285 304.04L369.483 304.312C369.67 303.848 370.147 303.401 371.004 303.401C371.826 303.401 372.248 303.831 372.248 304.572V304.602C372.248 305.067 371.771 305.058 370.595 305.195C369.355 305.339 368.085 305.663 368.085 307.151C368.085 308.438 369.052 309.145 370.297 309.145ZM370.574 308.122C369.853 308.122 369.333 307.798 369.333 307.168C369.333 306.486 369.939 306.243 370.676 306.145C371.089 306.089 372.069 305.979 372.252 305.795V306.639C372.252 307.415 371.635 308.122 370.574 308.122ZM377.674 309.128C378.867 309.128 379.336 308.399 379.566 307.982H379.673V309H380.917V300.273H379.643V303.516H379.566C379.336 303.111 378.901 302.369 377.683 302.369C376.102 302.369 374.938 303.618 374.938 305.74C374.938 307.858 376.085 309.128 377.674 309.128ZM377.955 308.041C376.817 308.041 376.225 307.04 376.225 305.727C376.225 304.428 376.805 303.452 377.955 303.452C379.067 303.452 379.664 304.359 379.664 305.727C379.664 307.104 379.055 308.041 377.955 308.041ZM386.013 300.273V309H387.266V302.68H387.347L389.921 308.987H390.961L393.535 302.685H393.616V309H394.869V300.273H393.271L390.492 307.057H390.39L387.612 300.273H386.013ZM399.438 309.132C401.283 309.132 402.489 307.781 402.489 305.757C402.489 303.72 401.283 302.369 399.438 302.369C397.593 302.369 396.387 303.72 396.387 305.757C396.387 307.781 397.593 309.132 399.438 309.132ZM399.442 308.062C398.236 308.062 397.674 307.01 397.674 305.753C397.674 304.5 398.236 303.435 399.442 303.435C400.64 303.435 401.202 304.5 401.202 305.753C401.202 307.01 400.64 308.062 399.442 308.062ZM403.911 309H405.185V305.003C405.185 304.146 405.846 303.528 406.749 303.528C407.013 303.528 407.312 303.575 407.414 303.605V302.386C407.286 302.369 407.035 302.357 406.873 302.357C406.106 302.357 405.45 302.791 405.211 303.494H405.143V302.455H403.911V309ZM411.103 309.132C412.531 309.132 413.541 308.429 413.831 307.364L412.625 307.146C412.395 307.764 411.841 308.08 411.116 308.08C410.025 308.08 409.292 307.372 409.258 306.111H413.912V305.659C413.912 303.294 412.497 302.369 411.014 302.369C409.19 302.369 407.988 303.759 407.988 305.77C407.988 307.803 409.173 309.132 411.103 309.132ZM409.262 305.156C409.314 304.227 409.987 303.422 411.022 303.422C412.011 303.422 412.659 304.155 412.663 305.156H409.262Z" fill="#454545"/>
+</svg>
+
+To implement this, we need to make **dynamic number of requests** on this page. React Hooks have [a couple of rules](https://reactjs.org/docs/hooks-rules.html), 
+so we **CANNOT** do something like this:
+
+```jsx highlight=5,6,7,8,9
+function App () {
+  const [cnt, setCnt] = useState(1)
+
+  const list = []
+  for (let i = 0; i < num; i++) {
+    // 🚨 This is wrong! Commonly, you can't use hooks inside a loop.
+    const { data } = useSWR(`/api/data?page=${i}`)
+    list.push(data)
+  }
+
+  return <div>
+    {list.map((data, i) => 
+      <div key={i}>{
+        data.map(item => <div key={item.id}>{item.name}</div>)
+      }</div>)}
+    <button onClick={() => setCnt(cnt + 1)}>Load More</button>
+  </div>
+}
+```
+
+Instead, we can ues the `<Page />` abstraction that we created to achieve it:
+
+```jsx highlight=5,6,7
+function App () {
+  const [cnt, setCnt] = useState(1)
+
+  const pages = []
+  for (let i = 0; i < cnt; i++) {
+    pages.push(<Page index={i} key={i} />)
+  }
+
+  return <div>
+    {pages}
+    <button onClick={() => setCnt(cnt + 1)}>Load More</button>
+  </div>
+}
+```
+
+### Advanced Cases
+
+However, in some advanced use cases, the solution above doesn't work.
+
+For example, we are still implementing the "Load More" UI, but we also need to display a number 
+about how many items are there in total. We can't use the `<Page />` solution anymore because
+the top level UI (`<App />`) needs the data inside each page:
+
+```jsx highlight=10
+function App () {
+  const [cnt, setCnt] = useState(1)
+
+  const pages = []
+  for (let i = 0; i < cnt; i++) {
+    pages.push(<Page index={i} key={i} />)
+  }
+
+  return <div>
+    <p>??? items</p>
+    {pages}
+    <button onClick={() => setCnt(cnt + 1)}>Load More</button>
+  </div>
+}
+```
+
+Also, if the pagination API is **cursor based**, that solution doesn't work either. Because each page
+needs the data from the previous page, they're not isolated.
+
+That's why we introduced this new `useSWRInfinite` Hook.
+
+## useSWRInfinite
+
+`useSWRInfinite` gives us the ability to trigger dynamic number of requests with one Hook. This is how it looks:
+
+```jsx
+const { data, error, isValidating, mutate, size, setSize } = useSWRInfinite(
+  getKey, fetcher?, options?
+)
+```
+
+Similar to `useSWR`, it accepts a function to get the key, a function to fetch the data, and an `options` object.
+Besides the `useSWR` return values, it also returns the page size and a function to set the size, like a React state.
+
+

--- a/pages/examples/infinite-loading.js
+++ b/pages/examples/infinite-loading.js
@@ -1,0 +1,21 @@
+import withNextraLayout from '.nextra/layout'
+
+const Layout = withNextraLayout('basic.js')
+
+export default () => {
+  return <Layout full title="Basic Usage">
+    <iframe
+      src="https://codesandbox.io/embed/swr-infinite-z6r0r?file=/src/App.js?fontsize=14&theme=dark&autoresize=1"
+      style={{
+        width: '100%',
+        height: '100%',
+        border: 0,
+        overflow: 'hidden',
+        background: 'rgb(21, 21, 21)'
+      }}
+      title="SWR - Infinite Loading"
+      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+      sandbox="allow-autoplay allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   />
+  </Layout>
+}

--- a/pages/examples/meta.json
+++ b/pages/examples/meta.json
@@ -1,4 +1,5 @@
 {
   "basic": "Basic Usage",
-  "auth": "Authentication"
+  "auth": "Authentication",
+  "infinite-loading": "Infinite Loading"
 }


### PR DESCRIPTION
This new API was already released at `swr@0.3.0`, this PR adds the corresponding docs and example of it.

https://swr-site-git-add-swr-infinite.vercel.vercel.app/docs/pagination
https://swr-site-git-add-swr-infinite.vercel.vercel.app/examples/infinite-loading