### PR TITLE
fix fetch params

### DIFF
--- a/pages/docs/global-configuration.md
+++ b/pages/docs/global-configuration.md
@@ -26,7 +26,7 @@ function App () {
     <SWRConfig 
       value={{
         refreshInterval: 3000,
-        fetcher: (...args) => fetch(...args).then(res => res.json())
+        fetcher: (input, init) => fetch(input, init).then(res => res.json())
       }}
     >
       <Dashboard />

--- a/pages/docs/global-configuration.md
+++ b/pages/docs/global-configuration.md
@@ -26,7 +26,7 @@ function App () {
     <SWRConfig 
       value={{
         refreshInterval: 3000,
-        fetcher: (input, init) => fetch(input, init).then(res => res.json())
+        fetcher: (resource, init) => fetch(resource, init).then(res => res.json())
       }}
     >
       <Dashboard />


### PR DESCRIPTION
Fetch takes only 2 arguments, spread operator on args will result in a typescript error. This commit makes it clear and strict that fetch takes an `input` and an `init` object.

More information here: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
Related error: `Expected 1-2 arguments, but got 0 or more.ts(2556)`