### PR TITLE
Rename option to config

### DIFF
--- a/pages/docs/error-handling.mdx
+++ b/pages/docs/error-handling.mdx
@@ -62,7 +62,7 @@ You can also override this behavior via the [onErrorRetry](/docs/options#options
 
 ```js
 useSWR('/api/user', fetcher, {
-  onErrorRetry: (error, key, option, revalidate, { retryCount }) => {
+  onErrorRetry: (error, key, config, revalidate, { retryCount }) => {
     // Never retry on 404.
     if (error.status === 404) return
 


### PR DESCRIPTION
In https://swr.vercel.app/docs/options#options the property is called `config`, and that is consistent with other callbacks SWR receive.