### PR TITLE
use a fake GraphQL endpoint instead of graph.cool

### DIFF
--- a/pages/docs/data-fetching.mdx
+++ b/pages/docs/data-fetching.mdx
@@ -56,7 +56,7 @@ Or using GraphQL with libs like [graphql-request](https://github.com/prisma-labs
 ```js
 import { request } from 'graphql-request'
 
-const fetcher = query => request('https://api.graph.cool/simple/v1/movies', query)
+const fetcher = query => request('/api/graphql', query)
 
 function App () {
   const { data, error } = useSWR(


### PR DESCRIPTION
ref. https://github.com/vercel/swr/pull/904

I've replaced a Graph.Cool endpoint with a fake GraphQL endpoint.
