### PR TITLE
fix: color contrast of a callout for suspense in the dark mode

### DIFF
--- a/pages/docs/suspense.mdx
+++ b/pages/docs/suspense.mdx
@@ -2,7 +2,7 @@ import Callout from 'nextra-theme-docs/callout'
 
 # Suspense
 
-<Callout emoji="🚨" background="bg-red-200">
+<Callout emoji="🚨" background="bg-red-200 dark:text-gray-800">
   Suspense is current an <strong>experimental</strong> feature of React. These APIs may change significantly and without a warning before they become a part of React.
   <br/>
   <a href="https://reactjs.org/docs/concurrent-mode-suspense.html" target="_blank" rel="noopener">More information</a>


### PR DESCRIPTION
The current callout for suspense in dark mode is hard to read.

https://swr.vercel.app/docs/suspense

Current:
![image](https://user-images.githubusercontent.com/250407/104917354-a28daf80-59d6-11eb-9bf3-026713c97c74.png)

<img width="430" alt="Screen Shot 2021-01-18 at 21 40 50" src="https://user-images.githubusercontent.com/250407/104917073-4591f980-59d6-11eb-883f-42c2d613d776.png">

After:
<img width="809" alt="image" src="https://user-images.githubusercontent.com/250407/104917336-9b66a180-59d6-11eb-9f02-a266d99af083.png">

<img width="407" alt="Screen Shot 2021-01-18 at 21 41 11" src="https://user-images.githubusercontent.com/250407/104917110-53e01580-59d6-11eb-908f-ac1f959c91f2.png">

