### PR TITLE
docs: add a warning for chaning the suspense option in the lifecycle

### DIFF
--- a/pages/docs/suspense.mdx
+++ b/pages/docs/suspense.mdx
@@ -32,6 +32,10 @@ function App () {
 }
 ```
 
+<Callout>
+  Note that the `suspense` option is not allowed to change in the lifecycle.
+</Callout>
+
 In Suspense mode, `data` is always the fetch response (so you don't need to check if it's `undefined`).
 But if an error occurred, you need to use an [error boundary](https://reactjs.org/docs/concurrent-mode-suspense.html#handling-errors) to catch it:
 


### PR DESCRIPTION
ref. https://github.com/vercel/swr/pull/898/files#r559133243

This adds a warning for changing the `suspense` option in the lifecycle.

<img width="842" alt="image" src="https://user-images.githubusercontent.com/250407/104918492-32802900-59d8-11eb-82dc-b1364f8c6e88.png">
