### PR TITLE
docs: add revalidate in the documentation

### DIFF
--- a/pages/docs/mutation.md
+++ b/pages/docs/mutation.md
@@ -29,6 +29,36 @@ function App () {
 }
 ```
 
+You can also use the `revalidate` function that `useSWR` returns.
+
+```jsx
+import useSWR from 'swr'
+
+function App () {
+  const { data, revalidate } = useSWR('/api/user', fetcher);
+  return (
+    <div>
+      <Profile />
+      <button onClick={() => {
+        // set the cookie as expired
+        document.cookie = 'token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;'
+
+        // tell all SWRs with this key to revalidate
+        revalidate()
+      }}>
+        Logout
+      </button>
+    </div>
+  )
+}
+```
+
+`revalidate` accepts `retryCount` and `dedupe` as an option argument.
+
+```jsx
+revalidate({ retryCount, dedupe })
+```
+
 ## Mutation and POST Request
 
 In many cases, applying local mutations to data is a good way to make changes

--- a/pages/docs/options.mdx
+++ b/pages/docs/options.mdx
@@ -8,15 +8,16 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 
 ## Parameters
 
-- `key`: a unique key string for the request (or a function / array / null) [(advanced usage)](/docs/conditional-fetching)  
-- `fetcher`: (_optional_) a Promise returning function to fetch your data [(details)](/docs/data-fetching) 
+- `key`: a unique key string for the request (or a function / array / null) [(advanced usage)](/docs/conditional-fetching)
+- `fetcher`: (_optional_) a Promise returning function to fetch your data [(details)](/docs/data-fetching)
 - `options`: (_optional_) an object of options for this SWR hook
 
 ## Return Values
-- `data`: data for the given key resolved by `fetcher` (or undefined if not loaded)  
-- `error`: error thrown by `fetcher` (or undefined)  
-- `isValidating`: if there's a request or revalidation loading  
+- `data`: data for the given key resolved by `fetcher` (or undefined if not loaded)
+- `error`: error thrown by `fetcher` (or undefined)
+- `isValidating`: if there's a request or revalidation loading
 - `mutate(data?, shouldRevalidate?)`: function to mutate the cached data
+- `revalidate({ retryCount, dedupe }?)`: function to revalidate the data
 
 ## Options
 


### PR DESCRIPTION
Currently, there is no documentation for `revalidate` that `useSWR` returns.
So I've added it to the documentation.

(Prettier has automatically removed whitespaces in end of line. If it shouldn't be, I'll remove it from the diffs)