### PR TITLE
docs: add missing return values of useSWRInfinite

### DIFF
--- a/pages/docs/pagination.mdx
+++ b/pages/docs/pagination.mdx
@@ -223,6 +223,8 @@ In infinite loading, one _page_ is one request, and our goal is to fetch multipl
 #### Return Values
 
 - `data`: an array of fetch response values of each page
+- `error`: same as `useSWR`'s `error`
+- `isValidating`: same as `useSWR`'s `isValidating`
 - `mutate`: same as `useSWR`'s bound mutate function but manipulates the data array
 - `size`: the number of pages that _will_ be fetched and returned
 - `setSize`: set the number of pages that need to be fetched


### PR DESCRIPTION
`useSWRInfinite` returns `error` and `isValidating`, but they are not documented, so I've added them into the document.