### PR TITLE
Updated link to prefetching in NextJS

### DIFF
--- a/pages/docs/prefetching.en-US.md
+++ b/pages/docs/prefetching.en-US.md
@@ -26,4 +26,4 @@ function prefetch () {
 }
 ```
 
-Together with techniques like [page prefetching](https://nextjs.org/docs#prefetching-pages) in Next.js, you will be able to load both next page and data instantly.
+Together with techniques like [page prefetching](https://nextjs.org/docs/api-reference/next/router#routerprefetch) in Next.js, you will be able to load both next page and data instantly.


### PR DESCRIPTION
It looks like this URL changed at some point, so updated to the current URL of router prefetching