### PR TITLE
Improve grammar in "Arguments"

### DIFF
--- a/pages/docs/arguments.en-US.md
+++ b/pages/docs/arguments.en-US.md
@@ -18,7 +18,7 @@ useSWR('/api/user', url => fetchWithToken(url, token))
 ```
 
 This is **incorrect**. Because the identifier (also the cache key) of the data is `'/api/user'`, 
-so even if `token` changes, SWR will still use the same key and return the wrong data. 
+even if `token` changes, SWR will still use the same key and return the wrong data. 
 
 Instead, you can use an **array** as the `key` parameter, which contains multiple arguments of `fetcher`:
 


### PR DESCRIPTION
Not terribly important, but the words "because" and "so" have the same function in this sentence, so using both is redundant and less clear.

- Before:
  - Because the identifier (also the cache key) of the data is `'/api/user'`, **so** even if `token` changes, SWR will still use the same key and return the wrong data.
- After:
  - Because the identifier (also the cache key) of the data is `'/api/user'`, even if `token` changes, SWR will still use the same key and return the wrong data.