### PR TITLE
I18n: Spanish

### DIFF
--- a/components/features.js
+++ b/components/features.js
@@ -11,6 +11,7 @@ const Feature = ({ text, icon }) => (
 
 const TITLE_WITH_TRANSLATIONS = {
   'en-US': 'React Hooks library for data fetching',
+  'es-ES': 'Biblioteca React Hooks para la obtención de datos',
   'zh-CN': '用于数据请求的 React Hooks 库'
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const withNextra = require('nextra')({
 
 module.exports = withNextra({
   i18n: {
-    locales: ['en-US', 'zh-CN'],
+    locales: ['en-US', 'zh-CN', 'es-ES'],
     defaultLocale: 'en-US'
   }
 })

--- a/pages/advanced/meta.es-ES.json
+++ b/pages/advanced/meta.es-ES.json
@@ -1,0 +1,3 @@
+{
+  "performance": "Rendimiento"
+}

--- a/pages/advanced/performance.es-ES.mdx
+++ b/pages/advanced/performance.es-ES.mdx
@@ -1,0 +1,122 @@
+# Rendimiento
+
+SWR proporciona una funcionalidad crítica en todo tipo de aplicaciónes web, por lo que el **rendimiento**
+es una prioridad absoluta.
+
+SWR’s tiene **caché** incorporado y la **[deduplicación](/advanced/performance#deduplication)** evitan las solicitudes de red innecesarias,
+pero el rendimiento del propio hook `useSWR` sigue siendo importante. En una aplicación compleja, puede haber cientos de llamadas `useSWR`
+en una solo página.
+
+SWR asegura que su aplicación tiene:
+
+- _no hay peticiones de red innecesarias_
+- _no hay renderizado innecesarios_
+- _no se importa código innecesario_
+
+sin ningún cambio de código por su parte.
+
+## Deduplicación
+
+Es muy común reutilizar los hooks SWR en tu aplicación. Por ejemplo, una aplicación que muestra el avatar del usuario
+actual 5 veces:
+
+```jsx
+
+function useUser() {
+   return useSWR('/api/user', fetcher)
+}
+
+function Avatar () {
+   const { data, error } = useUser()
+   if (error) return <Error />
+   if (!data) return <Spinner />
+
+   return <img src={data.avatar_url} />
+}
+
+function App() {
+  return <>
+    <Avatar />
+    <Avatar />
+    <Avatar />
+    <Avatar />
+    <Avatar />
+  </>
+}
+
+```
+
+Cada componente `<Avatar/>` tiene un hook `useSWR` en su interior. Dado que tienen el mismo key SWR y 
+que se renderizan casi al mismo tiempo, **sólo se hará 1 solicitud de red**.
+
+Puedes reutilizar tus hooks de datos (como `useUser` en el ejemplo anterior) en todas partes, sin preocuparte por el rendimiento
+o las peticiones duplicadas.
+
+También existe la [opción `dedupingInterval`](/docs/options) para anular el intervalo de deduplicación por defecto.
+
+## Comparación profunda
+
+SWR por defecto tiene  **deep compares** al cambio de datos. Si el valor de `data` no ha cambiado, no se
+activará una nueva renderización.
+
+También puede personalizar la función de comparación mediante la [opción `compare`](/docs/options) si quieres cambiar el comportamiento.
+Por ejemplo, algunas respuestas de la API devuelven una marca de tiempo del servidor que tal vez quiera excluir de la difusión de datos.
+
+## Coleción de dependencias
+
+`useSWR` devuelve 3 valores de **estado**: `data`, `error` y `isValidating` cada uno de ellos puede actualizarse de forma independientemente.
+Por ejemplo, si imprimimos esos valores dentro de un ciclo de vida completo de obtención de datos, será algo como esto:
+
+```jsx
+
+function App () {
+  const { data, error, isValidating } = useSWR('/api', fetcher)
+  console.log(data, error, isValidating)
+  return null
+}
+
+```
+
+En el peor de los casos (la primera solicitud falló, entonces el reitento fue exitoso), verá 4 líneas de registros:
+
+```js
+// console.log(data, error, isValidating)
+undefined undefined false // => hydration / initial render
+undefined undefined true  // => start fetching
+undefined Error false     // => end fetching, got an error
+undefined Error true      // => start retrying
+Data undefined false      // => end retrying, get the data
+```
+
+Los cambios de estado tienen sentido. Pero eso también significa que nuestro componente se **renderizo 4 veces.**
+
+Si cambiamos nuestro componente para usar solo `data`:
+
+```jsx
+
+function App () {
+   const { data } = useSWR('/api', fetcher)
+   console.log(data)
+   return null
+}
+```
+
+La magia ocurre - ahora solo hay **2 rederizaciones**:
+
+```js
+// console.log(data)
+undefined // => hydration / initial render
+Data      // => end retrying, get the data
+```
+
+El mismo proceso ha ocurrido internamente, hubo un error de la primera solicitud, entonces tenemos los datos del reintento.
+Sin embargo, **SWR sólo actualiza los estados que utiliza el componente**, que ahora sólo es `data`.
+
+Si no utiliza siempre estos 3 estados, ya se está beneficiando de esta función. En [Vercel](https://vercel.com), esta optimización se 
+traduce en un 60% menos de repeticiones.
+
+## Tree Shaking
+
+El paquete SWR es [tree-shakeable](https://webpack.js.org/guides/tree-shaking) y no tiene efectos secundarios.
+Esto significa que si sólo importa `useSWR` core API, las APIs no utilizadas, como `useSWRInfinite`, no se incluirán en tu aplicación.
+

--- a/pages/advanced/performance.es-ES.mdx
+++ b/pages/advanced/performance.es-ES.mdx
@@ -81,7 +81,7 @@ En el peor de los casos (la primera solicitud falló, entonces el reitento fue e
 
 ```js
 // console.log(data, error, isValidating)
-undefined undefined false // => hydration / initial render
+
 undefined undefined true  // => start fetching
 undefined Error false     // => end fetching, got an error
 undefined Error true      // => start retrying

--- a/pages/change-log.es-ES.mdx
+++ b/pages/change-log.es-ES.mdx
@@ -1,0 +1,27 @@
+import Markdown from 'markdown-to-jsx'
+import { useSSG } from 'nextra/ssg'
+
+export const getStaticProps = ({ params }) => {
+  return fetch('https://api.github.com/repos/vercel/swr/releases')
+    .then(res => res.json())
+    // we keep the most recent 5 releases here
+    .then(releases => ({ props: { ssg: releases.slice(0, 5) }, revalidate: 10 }))
+}
+
+export const ReleasesRenderer = () => {
+  const releases = useSSG()
+  return <Markdown>{
+    releases.map(release => {
+      const body = release.body
+        .replace(/&#39;/g, "'")
+        .replace(/@([a-zA-Z0-9_-]+)(?=(,| ))/g, '<a href="https://github.com/$1" target="_blank" rel="noopener">@$1</a>')
+      return `## <a href="${release.html_url}" target="_blank" rel="noopener">${release.tag_name}</a> 
+Publicado en ${new Date(release.published_at) .toDateString()}.\n\n${body}`}).join('\n\n')
+  }</Markdown>
+}
+
+# Registro de cambios
+
+Visite [SWR release page](https://github.com/vercel/swr/releases) para ver todo el historial de lanzamientos.
+
+<ReleasesRenderer/>

--- a/pages/docs/arguments.es-ES.md
+++ b/pages/docs/arguments.es-ES.md
@@ -1,0 +1,54 @@
+# Argumentos
+
+Por defecto, `key` se pasará a `fetcher` como argumento. Así que las siguientes 3 expresiones son equivalentes:
+
+```js
+useSWR('/api/user', () => fetcher('/api/user'))
+useSWR('/api/user', url => fetcher(url))
+useSWR('/api/user', fetcher)
+```
+
+## Argumentos múltiples
+
+En algunos escenarios, es útil pasar múltiples argumentos (puede pasar cualquier valor u objeto) a
+la función `fetcher`. Por ejemplo una solicitud de obtención autorizada:
+
+```js
+useSWR('/api/user', url => fetchWithToken(url, token))
+```
+
+Esto es **incorrecto**. Dado que el identificador (también la key del caché) de los datos es `'/api/user'`, incluso si el token cambia, SWR seguirá utilizando la misma key y devolverá los datos incorrectos.
+
+En su lugar, puedes utilizar un **array** como parámetro `key`, que contiene múltiples argumentos de `fetcher`:
+
+```js
+const { data: user } = useSWR(['/api/user', token], fetchWithToken)
+```
+
+La función `fetchWithToken` sigue aceptando los mismo 2 argumentos, pero ahora la key del caché también estará asociada al `token`.
+
+## Pasar objectos
+
+Digamos que tienes otra función que obtiene datos con un scope 
+del usuario: `fetchWithUser(api, user)`. Puedes hacer lo siguiente:
+
+```js
+const { data: user } = useSWR(['/api/user', token], fetchWithToken)
+// ...y pasarlo como un argumento a otra query
+const { data: orders } = useSWR(user ? ['/api/orders', user] : null, fetchWithUser)
+```
+La `key` de la solicitud es ahora la combinación de ambos valores. SWR **shallowly** compara los argumentos en cada renderización, 
+y activa la revalidación si alguno de ellos ha cambiado.
+
+Ten en cuenta que no debes recrear los objetos al renderizar, ya que serán tratados como objetos diferentes en cada render:
+
+```js
+// No lo hagas. Los deps se cambiarán en cada render.
+useSWR(['/api/user', { id }], query)
+
+// En su lugar, sólo debe pasar valores "estables".
+useSWR(['/api/user', id], (url, id) => query(url, { id }))
+```
+
+Dan Abramov explica muy bien las dependencias en [está entrada del blog](https://overreacted.io/a-complete-guide-to-useeffect/#but-i-cant-put-this-function-inside-an-effect).
+

--- a/pages/docs/conditional-fetching.es-ES.md
+++ b/pages/docs/conditional-fetching.es-ES.md
@@ -1,0 +1,37 @@
+# Búsqueda Condicional
+
+## Condicional
+
+Utilice `null` o pase una función como `key` para obtener datos de forma condicional. 
+Si la función lanza o devuelve un falsy value, SWR no iniciará la petición.
+
+
+```js
+// conditionally fetch
+const { data } = useSWR(shouldFetch ? '/api/data' : null, fetcher)
+
+// ...o devuelve un falsy value
+const { data } = useSWR(() => shouldFetch ? '/api/data' : null, fetcher)
+
+// ...o lanza un error cuando user.id no está definifo
+const { data } = useSWR(() => '/api/data?uid=' + user.id, fetcher)
+```
+
+## Dependiente
+
+SWR también permite obtener datos que dependen de otros datos. Garantiza el máximo paralelismo posible (evitando las cascadas), así como la obtención en serie cuando se necesita un dato dinámico para que se produzca la siguiente obtención de datos.
+
+```js
+function MyProjects () {
+  const { data: user } = useSWR('/api/user')
+  const { data: projects } = useSWR(() => '/api/projects?uid=' + user.id)
+  // Al pasar una función, SWR utilizará el valor devuelto
+  // como `key`. Si la función lanza o devuelve
+  // falsy, SWR sabrá que algunas dependencias no estan
+  // ready. En este caso `user.id` lanza cuando `user`
+  // no este cargado.
+
+  if (!projects) return 'loading...'
+  return 'You have ' + projects.length + ' projects'
+}
+```

--- a/pages/docs/data-fetching.es-ES.mdx
+++ b/pages/docs/data-fetching.es-ES.mdx
@@ -1,0 +1,79 @@
+import Callout from 'nextra-theme-docs/callout'
+import Link from 'next/link'
+
+# Obtención De Datos
+
+```js
+const { data, error } = useSWR(key, fetcher) 
+```
+
+Esta es la API fundamental de SWR. El `fetcher` aquí es una función asíncrona que **acepta el `key`** de SWR,
+y devuelve los datos.
+
+El valor devuelto será pasado como `data`, y si lanza, será capturado como `error`.
+
+<Callout emoji="💡">
+  Tenga en cuenta que el <code>fetcher</code> puede ser omitido de los parámetros si se 
+  <Link href="/docs/global-configuration"><a href="/docs/global-configuration">proporciona globalmente</a></Link>.
+</Callout>
+
+## Fetch
+
+Puedes utilizar cualquier librería para manejar data fetching, por ejemplo un `fetch` polyfill [developit/unfetch](https://github.com/developit/unfetch):
+
+```js
+import fetch from 'unfetch'
+
+const fetcher = url => fetch(url).then(r => r.json())
+
+function App () {
+  const { data, error } = useSWR('/api/data', fetcher)
+  // ...
+}
+```
+
+<Callout emoji="💡">
+  Si estás usando <strong>Next.js</strong>, no necesita importar este polyfill:
+  <br />
+  <a target="_blank" rel="noopener" href="https://nextjs.org/blog/next-9-1-7#new-built-in-polyfills-fetch-url-and-objectassign">Nuevos Polyfills Incorporados: fetch(), URL, y Object.assign</a>
+</Callout>
+
+## Axios
+
+```js
+import axios from 'axios'
+
+const fetcher = url => axios.get(url).then(res => res.data)
+
+function App () {
+  const { data, error } = useSWR('/api/data', fetcher)
+  // ...
+}
+```
+
+## GraphQL
+
+O utilizando GraphQL con librerías como [graphql-request](https://github.com/prisma-labs/graphql-request):
+
+```js
+import { request } from 'graphql-request'
+
+const fetcher = query => request('/api/graphql', query)
+
+function App () {
+  const { data, error } = useSWR(
+    `{
+      Movie(title: "Inception") {
+        releaseDate
+        actors {
+          name
+        }
+      }
+    }`,
+    fetcher
+  )
+  // ...
+}
+```
+
+_Si quiere pasar variables a una query GraphQL, consulte [Argumentos múltiples](/docs/arguments)._

--- a/pages/docs/error-handling.es-ES.mdx
+++ b/pages/docs/error-handling.es-ES.mdx
@@ -83,7 +83,7 @@ useSWR('/api/user', fetcher, {
 
 Este callback le da flexibilidad de reintentar basado en varias condiciones. También puede desactivar estableciendo `shouldRetryOnError: false`.
 
-También es posible propociona a través del [Global Configuration](/docs/global-configuration) context.
+También es posible propocionar a través del [Global Configuration](/docs/global-configuration) context.
 
 ## Informe global de errores
 

--- a/pages/docs/error-handling.es-ES.mdx
+++ b/pages/docs/error-handling.es-ES.mdx
@@ -1,0 +1,105 @@
+import Callout from 'nextra-theme-docs/callout'
+import Link from 'next/link'
+
+# Gestión De Errores
+
+Si se lanza un error dentro del [`fetcher`](/docs/data-fetching), será devuelto como `error` por el hook.
+
+```js
+const fetcher = url => fetch(url).then(r => res.json()) 
+
+// ...
+const { data, error } = useSWR('/api/user', fetcher)
+```
+
+El objeto `error` será definido si la promise de fetch es rechazada.
+
+## Código de estado y objeto de error
+
+A veces queremos que una API devuelva un objeto de error junto con el status code. 
+Ambos son útiles para el cliente.
+
+Podemos personanilizar nuestro `fetcher` para que devuelve más información. Si el status code no es `2xx`, lo consideramos
+un error aunque se pueda analizar como JSON:
+
+```js
+const fetcher = async url => {
+  const res = await fetch(url)
+
+  // Si el status code no esta en el rango 200-299,
+  // seguimos intentando analizarlo y lanzarlo.
+  if (!res.ok) {
+    const error = new Error('An error occurred while fetching the data.')
+    // Adjunta información extra al objeto de error.
+    error.info = await res.json()
+    error.status = res.status
+    throw error
+  }
+
+  return res.json()
+}
+
+// ...
+const { data, error } = useSWR('/api/user', fetcher)
+// error.info === {
+//   message: "You are not authorized to access this resource.",
+//   documentation_url: "..."
+// }
+// error.status === 403
+
+```
+
+<Callout emoji="💡">
+  Tenga en cuenta que `data` y `error` pueden existir al mismo tiempo. Por lo tanto la UI puede mostrar
+  data existente, mientras se sabe que la próxima solicitud ha fallado.
+</Callout>
+
+[Aquí](/examples/error-handling) tenemos un ejemplo.
+
+## Reintento de error
+
+SWR utiliza el [exponential backoff algorithm](https://en.wikipedia.org/wiki/Exponential_backoff) para reintentar la solicitud en el error.
+El algoritmo permite que la aplicación se recupere de los errores rápidamente, pero si malgastar recursos reintentando con demasiada frecuencia.
+
+También podemos anular este comportamiento mediante la opción [onErrorRetry](/docs/options#options):
+
+```js
+useSWR('/api/user', fetcher, {
+  onErrorRetry: (error, key, config, revalidate, { retryCount }) => {
+    // Never retry on 404.
+    if (error.status === 404) return
+
+    // Never retry for a specific key.
+    if (key === '/api/user') return
+
+    // Only retry up to 10 times.
+    if (retryCount >= 10) return
+
+    // Retry after 5 seconds.
+    setTimeout(() => revalidate({ retryCount }), 5000)
+  }
+})
+```
+
+Este callback le da flexibilidad de reintentar basado en varias condiciones. También puede desactivar estableciendo `shouldRetryOnError: false`.
+
+También es posible propociona a través del [Global Configuration](/docs/global-configuration) context.
+
+## Informe global de errores
+
+Siempre puedes obtener el objeto de `error` dentro del componente de forma reactiva. Pero en caso de que quieras manejar el error de forma global, 
+para notificar a la UI que muestre un [toast](https://vercel.com/design/toast) o un [snackbar](https://material.io/components/snackbars), o reportarlo 
+en algún lugar como [Sentry](https://sentry.io), hay un evento [`onError`](/docs/options#options):
+
+```jsx
+<SWRConfig value={{
+  onError: (error, key) => {
+    if (error.status !== 403 && error.status !== 404) {
+      // Podemos enviar el error a Sentry
+      // o mostrarlo una notificación UI.
+    }
+  }
+}}>
+  <MyApp />
+</SWRConfig>
+```

--- a/pages/docs/global-configuration.es-ES.md
+++ b/pages/docs/global-configuration.es-ES.md
@@ -1,0 +1,37 @@
+# Configuración Global
+
+El contexto `SWRConfig` puede proporcionar configuraciones globales ([opciones](/docs/options)) para todos los hooks de SWR.
+
+```jsx
+<SWRConfig value={options}>
+  <Component/>
+</SWRConfig>
+```
+
+En este ejemplo, todos los hooks de SWR utilizarán el mismo fetcher proporcionando para cargar datos JSON, 
+y se actualizarán cada 3 segundos por defecto:
+
+```jsx
+import useSWR, { SWRConfig } from 'swr'
+
+function Dashboard () {
+  const { data: events } = useSWR('/api/events')
+  const { data: projects } = useSWR('/api/projects')
+  const { data: user } = useSWR('/api/user', { refreshInterval: 0 }) // override
+
+  // ...
+}
+
+function App () {
+  return (
+    <SWRConfig 
+      value={{
+        refreshInterval: 3000,
+        fetcher: (resource, init) => fetch(resource, init).then(res => res.json())
+      }}
+    >
+      <Dashboard />
+    </SWRConfig>
+  )
+}
+```

--- a/pages/docs/meta.es-ES.json
+++ b/pages/docs/meta.es-ES.json
@@ -1,0 +1,14 @@
+{
+  "options": "Opciones",
+  "global-configuration": "Configuración Global",
+  "data-fetching": "Obtención De Datos",
+  "error-handling": "Gestión De Errores",
+  "revalidation": "Revalidación Automática",
+  "conditional-fetching": "Obtención De Datos Condicional",
+  "arguments": "Argumentos",
+  "mutation": "Mutación",
+  "pagination": "Paginación",
+  "prefetching": "Prefetching",
+  "with-nextjs": "Uso Con Next.js",
+  "suspense": "Suspense"
+}

--- a/pages/docs/mutation.es-ES.md
+++ b/pages/docs/mutation.es-ES.md
@@ -1,0 +1,141 @@
+# Mutación
+
+## Revalidar
+
+Se puede emitir un mensaje de revalidación de forma global a todos los SWRs con la misma key llamando a `mutate(key)`.
+
+Este ejemplo muestra cómo recuperar automáticamente la información de login (por ejemplo, dentro de `<Profile/>`) 
+cuando el usuario hace clic en el botón "Logout".
+
+```jsx
+import useSWR, { mutate } from 'swr'
+
+function App () {
+  return (
+    <div>
+      <Profile />
+      <button onClick={() => {
+        // establecer la cookie como caduca
+        document.cookie = 'token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;'
+
+        // indicar a todos SWRs con esta key que se revaliden
+        mutate('/api/user')
+      }}>
+        Logout
+      </button>
+    </div>
+  )
+}
+```
+
+## Mutación y solicitud POST
+
+En muchos casos, la aplicación de mutations locales a los datos es una buena forma de agilizar los cambios, 
+sin necesidad de esperar a la fuente de datos remota.
+
+Con `mutate`, puedes actualizar tus datos locales mediante programación, mientras los revalidas y finalmente los 
+sustituyes por los datos más recientes.
+
+```jsx
+import useSWR, { mutate } from 'swr'
+
+function Profile () {
+  const { data } = useSWR('/api/user', fetcher)
+
+  return (
+    <div>
+      <h1>My name is {data.name}.</h1>
+      <button onClick={async () => {
+        const newName = data.name.toUpperCase()
+        
+        // actualiza los datos locales inmediatamente, pero desactiva la revalidación
+        mutate('/api/user', { ...data, name: newName }, false)
+        
+        // envía una solicitud a la API para actualizar la fuente
+        await requestUpdateUsername(newName)
+        
+        // activar una revalidación (refetch) para asegurarse de que nuestros datos locales son correctos
+        mutate('/api/user')
+      }}>Uppercase my name!</button>
+    </div>
+  )
+}
+```
+
+Al hacer click en el botón del ejemplo anterior, se actualizarán localmente los datos del cliente, se enviará una solicitud POST 
+para modificar los datos remotos y se intentará obtener la última (revalidar).
+
+Pero muchas APIs POST simplemente devolverán los datos actualizados directamente, por lo que no necesitamos revalidar de nuevo. 
+Aquí hay un ejemplo que muestra el uso de "local mutate - request - update":
+
+
+```jsx
+mutate('/api/user', newUser, false)      // utilice `false` para mutate sin revalidar
+mutate('/api/user', updateUser(newUser)) // `updateUser` es una Promise de la solicitud,
+                                         // que devuelve el update document
+```
+
+## Mutar basándose en los datos actuales
+
+A veces, se desea actualizar una parte de los datos en función de los datos actuales.
+
+Con `mutate`, puedes pasar una función asíncrona que recibirá el valor actual de la caché, si lo hay, y devolverá un updated document.
+
+```jsx
+mutate('/api/todos', async todos => {
+  // actualicemos la tarea con ID `1` para que se complete,
+  // esta API devuelve los datos acutualizado
+  const updatedTodo = await fetch('/api/todos/1', {
+    method: 'PATCH',
+    body: JSON.stringify({ completed: true })
+  })
+
+  // filtrar la lista y devolverla con el item actualizado
+  const filteredTodos = todos.filter(todo => todo.id !== '1')
+  return [...filteredTodos, updatedTodo]
+})
+```
+
+## Datos devueltos por Mutate
+
+Lo más probable es que necesites algunos datos para actualizar la caché. Los datos se resuelven o se devuelven 
+desde la promise o función asíncrona que pasaste para `mutate`.
+
+La función devolverá update document para que `mutate` actualice el valor de la caché correspondiente. Podría arrojar un error de alguna manera, cada vez que se llame.
+
+
+```jsx
+try {
+  const user = await mutate('/api/user', updateUser(newUser))
+} catch (error) {
+  // Manejar un error al actualizar el user aquí
+}
+```
+
+## Bound Mutate
+
+El objeto SWR devuelto por `useSWR` también contiene una función `mutate()` que está atada a la key del SWR.
+
+Es funcionalmente equivalente a la función global `mutate` pero no requiere el parámetro `key`.
+
+```jsx
+import useSWR from 'swr'
+
+function Profile () {
+  const { data, mutate } = useSWR('/api/user', fetcher)
+
+  return (
+    <div>
+      <h1>My name is {data.name}.</h1>
+      <button onClick={async () => {
+        const newName = data.name.toUpperCase()
+        // enviar una solicitud a la API para actualizar los datos
+        await requestUpdateUsername(newName)
+        // actualizar los datos locales inmediatamente y revalidar (refetch)
+        // NOTA: la key no es necesaria cuando se utiliza el mutate de useSWR, es pre-bound
+        mutate({ ...data, name: newName })
+      }}>Uppercase my name!</button>
+    </div>
+  )
+}
+```

--- a/pages/docs/options.es-ES.mdx
+++ b/pages/docs/options.es-ES.mdx
@@ -1,0 +1,56 @@
+import Callout from 'nextra-theme-docs/callout'
+
+
+# API Options
+
+```js
+
+const { data, error, isValidating, mutate } = useSWR(key, fetcher, options) 
+```
+
+## Parámetros
+
+- `key`: un string key único para la solicitud (o una función / array / null) [(uso avanzado)](/docs/conditional-fetching)
+- `fetcher`: (_opcional_) una función que devuelve una Promise para recuperar sus datos [(detalles)](/docs/data-fetching)
+- `options`: (_opcional_) un objecto de opciónes para el hook useSWR
+
+## Valores devueltos
+
+- `data`: data de la key dada resueltos por el `fetcher` (o undefined si no está cargado)
+- `error`: error lanzado por el `fetcher` (o undefined)
+- `isValidating`: si hay una solicitud o carga de revalidación
+- `mutate(data?, shouldRevalidate?`: función para mutar los datos en caché
+
+## Opciónes
+
+- `suspense = false`: activar el modo React Suspense [(detalles)](/docs/suspense)
+- `fetcher = window.fetch(url).then(res => res.json())`: la fetcher función
+- `initialData`: datos iniciales a devolver (nota: Esto es por un hook) [(detalles)](/docs/with-nextjs)
+- `revalidateOnMount`: activar o desactivar la revalidación automática cuando se monta el componente 
+(por defecto la revalidación se produce en el montaje cuando initialData no está establecido, utilice esta flag para forzar el comportamiento)
+- `revalidateOnFocus = true`: revalidación automática cuanto window gets focused [(detalles)](/docs/revalidation)
+- `revalidateOnReconnect = true`: revalidación automática cuando el navegador recupera la conexión a la red 
+(a través de `navigator.onLine`) [(detalles)](/docs/revalidation)
+- `refreshInterval = 0`: polling interval (desactivado por defecto) [(detalles)](/docs/revalidation)
+- `refreshWhenHidden = false`: polling cuando window es invisible (si `refreshInterval` está activado)
+- `refreshWhenOffline = false`: polling cuando el navegador está desconectado (determinado por `navigator.onLine`)
+- `shouldRetryOnError = true`: reitentar cuando el fetcher tiene un error
+- `dedupingInterval = 2000`: solicitudes de deduplicación con la misma key en este lapso de tiempo
+- `focusThrottleInterval = 5000`: sólo revalidar una vez durante un periodo de tiempo
+- `loadingTimeout = 3000`: tiempo de espera para activar el evento onLoadingSlow
+- `errorRetryInterval = 5000`: error retry interval
+- `errorRetryCount`:  número máximo de reintentos de error
+- `onLoadingSlow(key, config)`: función callback cuando una petición tarda demasiado en cargase (véase: `loadingTimeout`)
+- `onSuccess(data, key, config)`: función callback cuando una petición termina con éxito
+- `onError(err, key, config)`: función callback cuando una petición devuelve un error
+- `onErrorRetry(err, key, config, revalidate, revalidateOps)`: manejador para el reintento de error
+- `compare(a, b)`: función de comparación utilizada para detectar cuando los datos devueltos han cambiado,
+para evitar spurious rerenders. Por defecto, se utiliza [dequal](https://github.com/lukeed/dequal).
+- `isPaused()`: para detectar si pause revalidations, ignorará los datos obtenidos y los errores cuando devuelva `true`. Devuelve `false` por defecto.
+
+<Callout emoji="💡">
+Cuando una red lenta (2G, {'<='} 70Kbps), `errorRetryInterval` serian 10 segundos, y 
+`loadingTimeout` serian 5 segundos por defecto.
+</Callout>
+
+También puede utilizar la [configuración global](/docs/global-configuration) para proporcionar opciónes por defecto.

--- a/pages/docs/pagination.es-ES.mdx
+++ b/pages/docs/pagination.es-ES.mdx
@@ -1,0 +1,344 @@
+import Callout from 'nextra-theme-docs/callout'
+
+# Paginación
+
+<Callout emoji="✅">
+  Por favor, actualice a la última versión (≥ 0.3.0) para utilizar esta API. La anterior API <code>useSWRPages</code> ha quedado obsoleta.
+</Callout>
+
+SWR proporciona una API dedicada `useSWRInfinite` para admitir patrones de UI comunes como la **paginación** y la **carga infinita**.
+
+## Cuándo utilizar `useSWR`
+
+### Paginación
+
+En primer lugar, es posible que **NO** necesitemos `useSWRInfinite`, sino que podemos utilizar simplemente `useSWR` 
+si estamos construyendo algo como esto:
+
+<div className="mt-8" />
+
+<svg viewBox="0 0 769 356" fill="none">
+<path d="M5 0.5H763C765.485 0.5 767.5 2.51472 767.5 5V351C767.5 353.485 765.485 355.5 763 355.5H5.00002C2.51473 355.5 0.5 353.485 0.5 351V5C0.5 2.51472 2.51472 0.5 5 0.5Z" fill="white" stroke="#EEEEEE"/>
+<path d="M1 288H769" stroke="#E5E5E5"/>
+<path d="M21 26H747V40H21V26Z" fill="#E5E5E5"/>
+<path d="M21 70H747V84H21V70Z" fill="#E5E5E5"/>
+<path d="M21 114H747V128H21V114Z" fill="#E5E5E5"/>
+<path d="M21 158H747V172H21V158Z" fill="#E5E5E5"/>
+<path d="M21 202H747V216H21V202Z" fill="#E5E5E5"/>
+<path d="M21 246H747V260H21V246Z" fill="#E5E5E5"/>
+<rect x="21.5" y="306.5" width="69" height="31" rx="2.5" fill="#FAFAFA" stroke="#D3D3D3"/>
+<path d="M40.82 327.055L41.587 326.288L39.0259 323.736H45.7163V322.628H39.0259L41.587 320.067L40.82 319.308L36.9464 323.182L40.82 327.055ZM51.3455 327H52.6623V323.932H54.4521C56.4762 323.932 57.4776 322.709 57.4776 321.098C57.4776 319.491 56.4847 318.273 54.4563 318.273H51.3455V327ZM52.6623 322.815V319.402H54.3157C55.6197 319.402 56.1523 320.109 56.1523 321.098C56.1523 322.087 55.6197 322.815 54.3327 322.815H52.6623ZM58.919 327H60.1932V323.003C60.1932 322.146 60.8537 321.528 61.7571 321.528C62.0213 321.528 62.3196 321.575 62.4219 321.605V320.386C62.294 320.369 62.0426 320.357 61.8807 320.357C61.1136 320.357 60.4574 320.791 60.2188 321.494H60.1506V320.455H58.919V327ZM66.1112 327.132C67.5387 327.132 68.5487 326.429 68.8384 325.364L67.6325 325.146C67.4023 325.764 66.8484 326.08 66.1239 326.08C65.033 326.08 64.3001 325.372 64.266 324.111H68.9194V323.659C68.9194 321.294 67.5046 320.369 66.0217 320.369C64.1978 320.369 62.9961 321.759 62.9961 323.77C62.9961 325.803 64.1808 327.132 66.1112 327.132ZM64.2702 323.156C64.3214 322.227 64.9947 321.422 66.0302 321.422C67.0188 321.422 67.6665 322.155 67.6708 323.156H64.2702ZM75.8974 320.455H74.5295L72.8761 325.491H72.8079L71.1502 320.455H69.7823L72.1602 327H73.5238L75.8974 320.455Z" fill="#454545"/>
+<rect x="307.5" y="306.5" width="69" height="31" rx="2.5" fill="#FAFAFA" stroke="#D3D3D3"/>
+<path d="M329.225 318.273H327.922V324.682H327.841L323.4 318.273H322.181V327H323.498V320.599H323.579L328.015 327H329.225V318.273ZM333.865 327.132C335.293 327.132 336.303 326.429 336.592 325.364L335.386 325.146C335.156 325.764 334.602 326.08 333.878 326.08C332.787 326.08 332.054 325.372 332.02 324.111H336.673V323.659C336.673 321.294 335.259 320.369 333.776 320.369C331.952 320.369 330.75 321.759 330.75 323.77C330.75 325.803 331.935 327.132 333.865 327.132ZM332.024 323.156C332.075 322.227 332.749 321.422 333.784 321.422C334.773 321.422 335.42 322.155 335.425 323.156H332.024ZM338.94 320.455H337.543L339.554 323.727L337.517 327H338.915L340.385 324.554L341.859 327H343.253L341.195 323.727L343.236 320.455H341.842L340.385 323.003L338.94 320.455ZM347.599 320.455H346.257V318.886H344.983V320.455H344.024V321.477H344.983V325.342C344.979 326.531 345.886 327.107 346.892 327.085C347.297 327.081 347.57 327.004 347.719 326.949L347.489 325.896C347.403 325.913 347.246 325.952 347.041 325.952C346.628 325.952 346.257 325.815 346.257 325.078V321.477H347.599V320.455ZM357.724 327.055L361.598 323.182L357.724 319.308L356.957 320.075L359.518 322.628H352.828V323.736H359.518L356.957 326.293L357.724 327.055Z" fill="#454545"/>
+<path d="M281.098 322.03C281.563 322.03 281.951 321.651 281.951 321.178C281.951 320.713 281.563 320.33 281.098 320.33C280.63 320.33 280.246 320.713 280.246 321.178C280.246 321.651 280.63 322.03 281.098 322.03ZM284.497 322.03C284.961 322.03 285.349 321.651 285.349 321.178C285.349 320.713 284.961 320.33 284.497 320.33C284.028 320.33 283.645 320.713 283.645 321.178C283.645 321.651 284.028 322.03 284.497 322.03ZM287.895 322.03C288.36 322.03 288.748 321.651 288.748 321.178C288.748 320.713 288.36 320.33 287.895 320.33C287.426 320.33 287.043 320.713 287.043 321.178C287.043 321.651 287.426 322.03 287.895 322.03Z" fill="black"/>
+<rect x="103.5" y="306.5" width="44" height="31" rx="2.5" fill="#FAFAFA" stroke="#D3D3D3"/>
+<path d="M126.653 318.273H125.37L123.193 319.696V320.957L125.281 319.594H125.332V327H126.653V318.273Z" fill="#454545"/>
+<rect x="160.5" y="306.5" width="44" height="31" rx="2.5" fill="#EDEDED" stroke="#B3B3B3"/>
+<path d="M179.498 327H185.242V325.871H181.313V325.807L183.048 323.991C184.646 322.376 185.102 321.605 185.102 320.629C185.102 319.227 183.96 318.153 182.315 318.153C180.683 318.153 179.489 319.21 179.489 320.804H180.746C180.742 319.866 181.347 319.253 182.289 319.253C183.175 319.253 183.849 319.798 183.849 320.668C183.849 321.439 183.389 321.993 182.451 322.986L179.498 326.045V327Z" fill="#454545"/>
+<rect x="217.5" y="306.5" width="44" height="31" rx="2.5" fill="#FAFAFA" stroke="#D3D3D3"/>
+<path d="M239.349 327.119C241.13 327.119 242.438 326.054 242.434 324.605C242.438 323.501 241.769 322.709 240.61 322.53V322.462C241.522 322.227 242.114 321.511 242.11 320.531C242.114 319.249 241.062 318.153 239.383 318.153C237.781 318.153 236.494 319.121 236.451 320.54H237.725C237.755 319.739 238.509 319.253 239.366 319.253C240.256 319.253 240.84 319.794 240.836 320.599C240.84 321.443 240.163 321.997 239.195 321.997H238.458V323.071H239.195C240.406 323.071 241.104 323.685 241.104 324.562C241.104 325.411 240.367 325.986 239.34 325.986C238.394 325.986 237.657 325.5 237.606 324.724H236.268C236.323 326.148 237.585 327.119 239.349 327.119Z" fill="#454545"/>
+</svg>
+
+...que es un típico UI de paginación. Veamos cómo se puede implementar fácilmente con
+`useSWR`:
+
+```jsx highlight=5
+function App () {
+  const [pageIndex, setPageIndex] = useState(0);
+
+  // La URL de la API incluye el índice de la página, que es un React state.
+  const { data } = useSWR(`/api/data?page=${pageIndex}`, fetcher);
+
+  // ... manejar los estados de carga y error
+
+  return <div>
+    {data.map(item => <div key={item.id}>{item.name}</div>)}
+    <button onClick={() => setPageIndex(pageIndex - 1)}>Previous</button>
+    <button onClick={() => setPageIndex(pageIndex + 1)}>Next</button>
+  </div>
+}
+```
+
+Además, podemos crear una abstracción para este "page component":
+
+```jsx highlight=13
+function Page ({ index }) {
+  const { data } = useSWR(`/api/data?page=${index}`, fetcher);
+
+  // ... manejar los estados de carga y error
+
+  return data.map(item => <div key={item.id}>{item.name}</div>)
+}
+
+function App () {
+  const [pageIndex, setPageIndex] = useState(0);
+
+  return <div>
+    <Page index={pageIndex}/>
+    <button onClick={() => setPageIndex(pageIndex - 1)}>Previous</button>
+    <button onClick={() => setPageIndex(pageIndex + 1)}>Next</button>
+  </div>
+}
+```
+
+Gracias a la caché de SWR, tenemos la ventaja de precargar la siguiente página. 
+La página siguiente se presenta dentro de un hidden div, por lo que SWR activará la obtención de datos 
+de la página siguiente. Cuando el usuario navega a la siguiente página, los datos ya están allí:
+
+```jsx highlight=6
+function App () {
+  const [pageIndex, setPageIndex] = useState(0);
+
+  return <div>
+    <Page index={pageIndex}/>
+    <div style={{ display: 'none' }}><Page index={pageIndex + 1}/></div>
+    <button onClick={() => setPageIndex(pageIndex - 1)}>Previous</button>
+    <button onClick={() => setPageIndex(pageIndex + 1)}>Next</button>
+  </div>
+}
+```
+
+Con sólo 1 línea de código, conseguimos una UX mucho mejor. El hook `useSWR` es tan potente, 
+que la mayoría de los escenarios están cubiertos por él.
+
+### Carga infinita
+
+A veces queremos construir una UI de **carga infinita**, con un botón "Load More" que añada datos
+a la lista (o que lo haga automáticamente al desplazarse):
+
+<div className="mt-8" />
+
+<svg viewBox="0 0 769 356" fill="none">
+<path d="M5 0.5H763C765.485 0.5 767.5 2.51472 767.5 5V351C767.5 353.485 765.485 355.5 763 355.5H5.00002C2.51473 355.5 0.5 353.485 0.5 351V5C0.5 2.51472 2.51472 0.5 5 0.5Z" fill="white" stroke="#EEEEEE"/>
+<path d="M21 26H747V40H21V26Z" fill="#E5E5E5"/>
+<path d="M21 70H747V84H21V70Z" fill="#E5E5E5"/>
+<path d="M21 114H747V128H21V114Z" fill="#E5E5E5"/>
+<path d="M21 158H747V172H21V158Z" fill="#E5E5E5"/>
+<path d="M21 202H747V216H21V202Z" fill="#E5E5E5"/>
+<path d="M21 246H747V260H21V246Z" fill="#E5E5E5"/>
+<rect x="21.5" y="288.5" width="725" height="31" rx="2.5" fill="#FAFAFA" stroke="#D3D3D3"/>
+<path d="M354.49 309H359.761V307.866H355.807V300.273H354.49V309ZM363.918 309.132C365.763 309.132 366.969 307.781 366.969 305.757C366.969 303.72 365.763 302.369 363.918 302.369C362.073 302.369 360.867 303.72 360.867 305.757C360.867 307.781 362.073 309.132 363.918 309.132ZM363.923 308.062C362.717 308.062 362.154 307.01 362.154 305.753C362.154 304.5 362.717 303.435 363.923 303.435C365.12 303.435 365.683 304.5 365.683 305.753C365.683 307.01 365.12 308.062 363.923 308.062ZM370.297 309.145C371.379 309.145 371.988 308.595 372.231 308.105H372.282V309H373.527V304.653C373.527 302.749 372.027 302.369 370.987 302.369C369.802 302.369 368.711 302.847 368.285 304.04L369.483 304.312C369.67 303.848 370.147 303.401 371.004 303.401C371.826 303.401 372.248 303.831 372.248 304.572V304.602C372.248 305.067 371.771 305.058 370.595 305.195C369.355 305.339 368.085 305.663 368.085 307.151C368.085 308.438 369.052 309.145 370.297 309.145ZM370.574 308.122C369.853 308.122 369.333 307.798 369.333 307.168C369.333 306.486 369.939 306.243 370.676 306.145C371.089 306.089 372.069 305.979 372.252 305.795V306.639C372.252 307.415 371.635 308.122 370.574 308.122ZM377.674 309.128C378.867 309.128 379.336 308.399 379.566 307.982H379.673V309H380.917V300.273H379.643V303.516H379.566C379.336 303.111 378.901 302.369 377.683 302.369C376.102 302.369 374.938 303.618 374.938 305.74C374.938 307.858 376.085 309.128 377.674 309.128ZM377.955 308.041C376.817 308.041 376.225 307.04 376.225 305.727C376.225 304.428 376.805 303.452 377.955 303.452C379.067 303.452 379.664 304.359 379.664 305.727C379.664 307.104 379.055 308.041 377.955 308.041ZM386.013 300.273V309H387.266V302.68H387.347L389.921 308.987H390.961L393.535 302.685H393.616V309H394.869V300.273H393.271L390.492 307.057H390.39L387.612 300.273H386.013ZM399.438 309.132C401.283 309.132 402.489 307.781 402.489 305.757C402.489 303.72 401.283 302.369 399.438 302.369C397.593 302.369 396.387 303.72 396.387 305.757C396.387 307.781 397.593 309.132 399.438 309.132ZM399.442 308.062C398.236 308.062 397.674 307.01 397.674 305.753C397.674 304.5 398.236 303.435 399.442 303.435C400.64 303.435 401.202 304.5 401.202 305.753C401.202 307.01 400.64 308.062 399.442 308.062ZM403.911 309H405.185V305.003C405.185 304.146 405.846 303.528 406.749 303.528C407.013 303.528 407.312 303.575 407.414 303.605V302.386C407.286 302.369 407.035 302.357 406.873 302.357C406.106 302.357 405.45 302.791 405.211 303.494H405.143V302.455H403.911V309ZM411.103 309.132C412.531 309.132 413.541 308.429 413.831 307.364L412.625 307.146C412.395 307.764 411.841 308.08 411.116 308.08C410.025 308.08 409.292 307.372 409.258 306.111H413.912V305.659C413.912 303.294 412.497 302.369 411.014 302.369C409.19 302.369 407.988 303.759 407.988 305.77C407.988 307.803 409.173 309.132 411.103 309.132ZM409.262 305.156C409.314 304.227 409.987 303.422 411.022 303.422C412.011 303.422 412.659 304.155 412.663 305.156H409.262Z" fill="#454545"/>
+</svg>
+
+
+Para implementar esto, necesitamos hacer **número de peticiones dinámicas** en esta página. Los React Hooks tienen [un par de reglas](https://reactjs.org/docs/hooks-rules.html),
+por lo que **NO PODEMOS** hacer algo así:
+
+```jsx highlight=5,6,7,8,9
+function App () {
+  const [cnt, setCnt] = useState(1)
+
+  const list = []
+  for (let i = 0; i < cnt; i++) {
+    // 🚨 Esto es un error. Comúnmente, no se pueden usar hooks dentro de un bucle.
+    const { data } = useSWR(`/api/data?page=${i}`)
+    list.push(data)
+  }
+
+  return <div>
+    {list.map((data, i) =>
+      <div key={i}>{
+        data.map(item => <div key={item.id}>{item.name}</div>)
+      }</div>)}
+    <button onClick={() => setCnt(cnt + 1)}>Load More</button>
+  </div>
+}
+```
+
+En su lugar, podemos utilizar la abstracción `<Page />` que hemos creado para conseguirlo:
+
+```jsx highlight=5,6,7
+function App () {
+  const [cnt, setCnt] = useState(1)
+
+  const pages = []
+  for (let i = 0; i < cnt; i++) {
+    pages.push(<Page index={i} key={i} />)
+  }
+
+  return <div>
+    {pages}
+    <button onClick={() => setCnt(cnt + 1)}>Load More</button>
+  </div>
+}
+```
+
+### Casos avanzados
+
+Sin embargo, en algunos casos de uso avanzado, la solución anterior no funciona.
+
+Por ejemplo, seguimos implementando la misma UI "Load More", pero también necesitamos mostrar un número
+sobre cuántos item hay en total. No podemos utilizar la solución `<Page />` porque
+la UI de nivel superior (`<App />`) necesita los datos dentro de cada página:
+
+```jsx highlight=10
+function App () {
+  const [cnt, setCnt] = useState(1)
+
+  const pages = []
+  for (let i = 0; i < cnt; i++) {
+    pages.push(<Page index={i} key={i} />)
+  }
+
+  return <div>
+    <p>??? items</p>
+    {pages}
+    <button onClick={() => setCnt(cnt + 1)}>Load More</button>
+  </div>
+}
+```
+
+Además, si la API de paginación es **cursor based**, esa solución tampoco funciona. Porque cada página
+necesita los datos de la página anterior, no están aisladas.
+
+Así es como este nuevo hook `useSWRInfinite` puede ayudar.
+
+## useSWRInfinite
+
+`useSWRInfinite` nos da la posibilidad de lanzar un número de peticiones con un solo Hook. Así es como se ve:
+
+```jsx
+const { data, error, isValidating, mutate, size, setSize } = useSWRInfinite(
+  getKey, fetcher?, options?
+)
+```
+
+Al igual que `useSWR`, este nuevo hook acepta una función que devuelve la key de la solicitud, un fetcher función y options.
+Devuelve todos los valores que devuelve `useSWR`, incluyendo 2 valores extra: page size y page size setter, como un React state.
+
+En la carga infinita, una _page_ es una petición, y nuestro objetivo es obtener varias páginas y renderizarlas.
+
+### API
+
+#### Parametrós
+
+- `getKey`: una función que acepta el índice y los datos de la página anterior, devuelve la key de una página
+- `fetcher`: igual que la función [fetcher](/docs/data-fetching) de `useSWR`
+- `options`: acepta todas las opciones que soporta `useSWR`, con 3 opciones adicionales:
+  - `initialSize = 1`: número de páginas que deben cargarse inicialmente
+  - `revalidateAll = false`: intentar siempre revalidar todas las páginas
+  - `persistSize = false`: no restablecer el page size a 1 (o `initialSize` si está establecido) cuando la key de la primera página cambia
+
+<Callout>
+    Tenga en cuenta que la opción `InitialSize` no puede cambiar en el ciclo de vida.
+</Callout>
+
+#### Valores de retorno
+
+- `data`: una array de valores de respuesta fetch de cada página
+- `error`: El mismo valor devuelto de `error` que `useSWR`
+- `isValidating`: El mismo valor devuelto de `isValidating` que `useSWR`
+- `mutate`: same as `useSWR`'s bound mutate function but manipulates the data array
+- `size`: el número de páginas que _se obtendrán_ y devolverán
+- `setSize`: establecer el número de páginas que deben ser recuperadas
+
+### Ejemplo 1: API paginada basada en índices
+
+Para las APIs normales basadas en índices:
+
+```
+GET /users?page=0&limit=10
+[
+  { name: 'Alice', ... },
+  { name: 'Bob', ... },
+  { name: 'Cathy', ... },
+  ...
+]
+```
+
+```jsx highlight=4,5,6,7,10
+// Una función para obtener la key de SWR de cada página,
+// su valor de retorno será aceptado por `fetcher`.
+// Si se devuelve `null`, la petición de esa página no se iniciará.
+const getKey = (pageIndex, previousPageData) => {
+  if (previousPageData && !previousPageData.length) return null // reached the end
+  return `/users?page=${pageIndex}&limit=10`                    // SWR key
+}
+
+function App () {
+  const { data, size, setSize } = useSWRInfinite(getKey, fetcher)
+  if (!data) return 'loading'
+
+  // Ahora podemos calcular el número de todos los usuarios
+  let totalUsers = 0
+  for (let i = 0; i < data.length; i++) {
+    totalUsers += data[i].length
+  }
+
+  return <div>
+    <p>{totalUsers} users listed</p>
+    {data.map((users, index) => {
+      // `data` es un array con la respuesta de la API de cada página.
+      return users.map(user => <div key={user.id}>{user.name}</div>)
+    })}
+    <button onClick={() => setSize(size + 1)}>Load More</button>
+  </div>
+}
+```
+
+La función `getKey` es la mayor diferencia entre `useSWRInfinite` y `useSWR`.
+Acepta el índice de la página actual, así como los datos de la página anterior.
+Así que tanto la API de paginación basada en el índice como la basada en el cursor pueden ser soportadas de forma adecuada.
+
+Además, la `data` ya no son sólo es una respuesta de la API. Es una array de múltiples respuestas de la API:
+
+```js
+// `data` tendrá el siguiente aspecto
+[
+  [
+    { name: 'Alice', ... },
+    { name: 'Bob', ... },
+    { name: 'Cathy', ... },
+    ...
+  ],
+  [
+    { name: 'John', ... },
+    { name: 'Paul', ... },
+    { name: 'George', ... },
+    ...
+  ],
+  ...
+]
+```
+
+### Ejemplo 2: Cursor or Offset Based Paginated API
+
+Digamos que la API ahora requiere un cursor y devuelve el siguiente cursor junto con los datos:
+
+```
+GET /users?cursor=123&limit=10
+{
+  data: [
+    { name: 'Alice' },
+    { name: 'Bob' },
+    { name: 'Cathy' },
+    ...
+  ],
+  nextCursor: 456
+}
+```
+
+Podemos cambiar nuestra función `getKey` por:
+
+```jsx
+const getKey = (pageIndex, previousPageData) => {
+  // reached the end
+  if (previousPageData && !previousPageData.data) return null
+
+  // la primera página, no tenemos `previousPageData`.
+  if (pageIndex === 0) return `/users?limit=10`
+
+  // añadir el cursor al punto final de la API
+  return `/users?cursor=${previousPageData.nextCursor}&limit=10`
+}
+```
+
+### Características avanzadas
+
+[Aquí hay un ejemplo](/examples/infinite-loading) que muestra cómo se pueden implementar las siguientes características con `useSWRInfinite`:
+
+- estados de carga
+- mostrar una UI especial si está vacía
+- desactivar el botón "Load More" si reached the end
+- fuente de datos modificable
+- actualizar toda la lista

--- a/pages/docs/prefetching.es-ES.md
+++ b/pages/docs/prefetching.es-ES.md
@@ -1,0 +1,29 @@
+# Prefetching Data
+
+## Top-Level Page Data
+
+Hay muchas formas de precargar los datos para SWR. Para las solicitudes de nivel superior, [`rel="preload"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content) es muy recomendable:
+
+```html
+<link rel="preload" href="/api/data" as="fetch" crossorigin="anonymous">
+```
+
+Sólo tienes que ponerlo dentro de tu HTML `<head>`. Es fácil, rápido y nativo.
+
+Se precargarán los datos cuando se cargue el HTML, incluso antes de que el JavaScript comience a descargarse. Todas las solicitudes de fetch entrantes con la misma URL reutilizarán el resultado (incluyendo SWR, por supuesto).
+
+## Programmatically Prefetch
+
+A veces, se quiere precargar un recurso de forma condicional. Por ejemplo, precargar los datos cuando el usuario está [hovering](https://github.com/GoogleChromeLabs/quicklink) [a](https://github.com/guess-js/guess) [link](https://instant.page). La forma más intuitiva es tener una función que recupere y fije la caché a través de la función global [mutate](/docs/mutation):
+
+```js
+import { mutate } from 'swr'
+
+function prefetch () {
+  mutate('/api/data', fetch('/api/data').then(res => res.json()))
+  // el segundo parametró es una Promise
+  // SWR utilizará el resultado cuando resuelva
+}
+```
+
+Junto con técnicas como [page prefetching](https://nextjs.org/docs/api-reference/next/router#routerprefetch) en Next.js, podrás cargar tanto la siguiente página como los datos al instante.

--- a/pages/docs/revalidation.es-ES.mdx
+++ b/pages/docs/revalidation.es-ES.mdx
@@ -1,0 +1,61 @@
+import Video from 'components/video'
+import Callout from 'nextra-theme-docs/callout'
+import Bleed from 'nextra-theme-docs/bleed'
+import Link from 'next/link'
+
+# Revalidación Automática
+
+<Callout>
+  Si quiere revalidar manualmente los datos, compruebe <Link href="/docs/mutation"><a href="/docs/mutation">mutation</a></Link>.
+</Callout>
+
+## Revalidar on focus
+
+Al reenfocar una pagina o cambiar entre tabs, SWR revalida automáticamente los datos.
+
+Esto puede ser útil para sincronizar inmediatamente a el último estado. Esto es útil para refrescar los datos en escenarios
+como stale mobile tabs, o laptops que están **suspendida**.
+
+<Bleed>
+  <Video
+    src="https://raw.githubusercontent.com/vercel/swr-site/master/.github/videos/focus-revalidate.mp4"
+    caption="Vídeo: uso de la revalidación focus para sincronizar automáticamente el estado login entre páginas."
+    ratio={307/768}
+  />
+</Bleed>
+
+Esta caracteristica está activada por defecto. Puede desactivarla mediante de la opción [`revalidateOnFocus`](/docs/options).
+
+## Revalidar on interval
+
+En muchos casos, los datos cambian debido a los múltiples dispositivos, los múltiples usuarios, los múltiples tabs. ¿Cómo podemos
+con el tiempo actualizar los datos en pantalla?
+
+SWR le dará la opción de recuperar los datos automáticamente. Es **inteligente**, lo que significa que el refetching sólo se producirá si el 
+componente asociado al hook está **en la pantalla**.
+
+<Bleed>
+  <Video
+    src="https://raw.githubusercontent.com/vercel/swr-site/master/.github/videos/refetch-interval.mp4"
+    caption="Vídeo: cuando un usuario realiza un cambio, ambas sesiones acabarán por mostrar los mismo datos."
+    ratio={307/768}
+  />
+</Bleed>
+
+Puede activarlo estableciendo un valor de [`refreshInterval`](/docs/options).
+
+```js
+useSWR('/api/todos', fetcher, { refreshInterval: 1000 })
+```
+
+También hay opciones como `refreshWhenHidden` y `refreshWhenOffline`. Ambas están deshabilitadas por defecto, 
+para que SWR no recupere la información cuando la página web no esté en pantalla o no haya conexión de red.
+
+## Revalidar on reconnect
+
+También es útil revalidar cuando el usuario vuelve a estar conectado. 
+Este escenario se da con frecuencia cuando el usuario desbloquea su ordenador, pero en ese mismo momento no está conectado a Internet.
+
+Para asegurarse de que los datos están siempre actualizados, SWR revalida automáticamente cuando la red se recupera.
+
+Esta función está activada por defecto. Puede desactivarla mediante la opción [`revalidateOnReconnect`](/docs/options).

--- a/pages/docs/suspense.es-ES.mdx
+++ b/pages/docs/suspense.es-ES.mdx
@@ -1,0 +1,77 @@
+import Callout from 'nextra-theme-docs/callout'
+
+# Suspense
+
+<Callout emoji="🚨" background="bg-red-200 dark:text-gray-800">
+  Suspense es actualmente una característica <strong>experimental</strong> de React. Estas APIs pueden cambiar significativamente y sin previo aviso antes de que se conviertan en parte de React.
+  <br/>
+  <a href="https://reactjs.org/docs/concurrent-mode-suspense.html" target="_blank" rel="noopener">Más información</a>
+</Callout>
+
+<Callout>
+    Tenga en cuenta que React Suspense aún no es compatible con el modo SSR.
+</Callout>
+
+Puede activar la opción `suspense` para utilizar SWR con React Suspense:
+
+```jsx
+import { Suspense } from 'react'
+import useSWR from 'swr'
+
+function Profile () {
+  const { data } = useSWR('/api/user', fetcher, { suspense: true })
+  return <div>hello, {data.name}</div>
+}
+
+function App () {
+  return (
+    <Suspense fallback={<div>loading...</div>}>
+      <Profile/>
+    </Suspense>
+  )
+}
+```
+
+<Callout>
+    Tenga en cuenta que la opción `suspense` no puede cambiar en el ciclo de vida.
+</Callout>
+
+En el modo Suspense, `data` es siempre la respuesta fetch (por lo que no es necesario comprobar si es `undefined`).
+Pero si se produce un error, es necesario utilizar un [error boundary](https://reactjs.org/docs/concurrent-mode-suspense.html#handling-errors) para atraparlo:
+
+```jsx
+<ErrorBoundary fallback={<h2>Could not fetch posts.</h2>}>
+  <Suspense fallback={<h1>Loading posts...</h1>}>
+    <Profile />
+  </Suspense>
+</ErrorBoundary>
+```
+
+---
+
+### Note: With Conditional Fetching
+
+Normalmente, cuando se habilita `suspense` se garantiza que `data` siempre estarán lista al renderizar:
+
+```jsx
+function Profile () {
+  const { data } = useSWR('/api/user', fetcher, { suspense: true })
+
+  // `data` nunca sera `undefined`
+  // ...
+}
+```
+
+Sin embargo, cuando se utiliza junto con el conditional fetching o dependent fetching, `data` estará `undefined` si la solicitud está **paused**:
+
+```jsx
+function Profile () {
+  const { data } = useSWR(isReady ? '/api/user' : null, fetcher, { suspense: true })
+
+  // `data` será `undefined` si `isReady` es false
+  // ...
+}
+```
+
+Si quiere leer más detalles técnicos sobre esta restricción, consulte [la discusión aquí](https://github.com/vercel/swr/pull/357#issuecomment-627089889).
+

--- a/pages/docs/with-nextjs.es-ES.md
+++ b/pages/docs/with-nextjs.es-ES.md
@@ -1,0 +1,49 @@
+import Callout from 'nextra-theme-docs/callout'
+
+# Uso con Next.js
+
+## Obtención de datos del lado del cliente
+
+Si su página contiene datos que se actualizan con frecuencia y no necesita renderizar previamente los datos, SWR se adapta perfectamente y no se necesita una configuración especial: solo importe `useSWR` y use el hook dentro de cualquier componente que use los datos.
+
+Así es como funciona:
+
+- En primer lugar, muestre inmediatamente la página sin datos. Puede mostrar un loading state para los datos que faltan.
+
+- A continuación, se obtienen los datos en el lado del cliente y se muestran cuando están listos.
+
+Este enfoque funciona bien, por ejemplo, para páginas que son dashboard. Dado que un dashboard es una página privada y específica del usuario, el SEO no es relevante y la página no necesita ser pre-rendering. Los datos se actualizan con frecuencia, lo que requiere la obtención de datos en el momento de la solicitud.
+
+## Pre-rendering
+
+Si la página debe ser pre-rendering, Next.js soporta [2 formas de pre-rendering](https://nextjs.org/docs/basic-features/data-fetching):  
+**Static Generation (SSG)** y **Server-side Rendering (SSR)**.
+
+Junto con SWR, puede hacer pre-rendering la página para el SEO, y también tener características como el almacenamiento en caché, revalidation, el focus tracking, refetching on interval en el lado del cliente.
+
+Puedes pasar los pre-fetched data como valor inicial a la opción `initialData`. Por ejemplo, junto con [`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation):
+
+```jsx
+ export async function getStaticProps() {
+  // `getStaticProps` se invoca en el lado del servidor,
+  //  por lo que esta función `fetcher` se ejecutará en el server-side.
+  const posts = await fetcher('/api/posts')
+  return { props: { posts } }
+}
+
+function Posts (props) {
+  // Aquí la función `fetcher` se ejecutará en el client-side.
+  const { data } = useSWR('/api/posts', fetcher, { initialData: props.posts })
+
+  // ...
+}
+```
+
+La página sigue siendo pre-rendered. Eso significa que es amigable con el SEO, puede ser cacheada y se accede a ella muy rápido. Pero después de la hidratación, también es totalmente alimentado por SWR en el lado del cliente. Lo que significa que los datos pueden ser dinámicos y actualizarse con el tiempo y las interacciones del usuario.
+
+<Callout emoji="💡">
+   En el ejemplo anterior, <code>fetcher</code> se utiliza para cargar los datos tanto del cliente como del servidor, 
+   y tiene que soportar ambos entornos. Pero esto no es un requisito. Puedes utilizar diferentes formas de cargar los datos desde el servidor o desde el cliente.
+</Callout>
+
+

--- a/pages/examples/auth.es-ES.mdx
+++ b/pages/examples/auth.es-ES.mdx
@@ -1,0 +1,18 @@
+---
+title: Authentication
+full: true
+---
+
+<iframe
+  src="https://codesandbox.io/embed/swr-auth-tuqtf?fontsize=14&theme=dark&autoresize=1"
+  style={{
+    width: '100%',
+    height: '100%',
+    border: 0,
+    overflow: 'hidden',
+    background: 'rgb(21, 21, 21)'
+  }}
+  title="SWR - Authentication"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-autoplay allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+/>

--- a/pages/examples/basic.es-ES.mdx
+++ b/pages/examples/basic.es-ES.mdx
@@ -1,0 +1,18 @@
+---
+title: Basic Usage
+full: true
+---
+
+<iframe
+  src="https://codesandbox.io/embed/swr-0n32d?fontsize=14&theme=dark&autoresize=1"
+  style={{
+    width: '100%',
+    height: '100%',
+    border: 0,
+    overflow: 'hidden',
+    background: 'rgb(21, 21, 21)'
+  }}
+  title="SWR - Basic Usage"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-autoplay allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+/>

--- a/pages/examples/error-handling.es-ES.mdx
+++ b/pages/examples/error-handling.es-ES.mdx
@@ -1,0 +1,18 @@
+---
+title: Error Handling
+full: true
+---
+
+<iframe
+  src="https://codesandbox.io/embed/swr-states-4une7?fontsize=14&theme=dark&autoresize=1"
+  style={{
+    width: '100%',
+    height: '100%',
+    border: 0,
+    overflow: 'hidden',
+    background: 'rgb(21, 21, 21)'
+  }}
+  title="SWR - Error Handling"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-autoplay allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+/>

--- a/pages/examples/infinite-loading.es-ES.mdx
+++ b/pages/examples/infinite-loading.es-ES.mdx
@@ -1,0 +1,18 @@
+---
+title: Infinite Loading
+full: true
+---
+
+<iframe
+  src="https://codesandbox.io/embed/swr-infinite-z6r0r?file=/src/App.js?fontsize=14&theme=dark&autoresize=1"
+  style={{
+    width: '100%',
+    height: '100%',
+    border: 0,
+    overflow: 'hidden',
+    background: 'rgb(21, 21, 21)'
+  }}
+  title="SWR - Infinite Loading"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-autoplay allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+/>

--- a/pages/examples/meta.es-ES.json
+++ b/pages/examples/meta.es-ES.json
@@ -1,0 +1,6 @@
+{
+  "basic": "Uso Básico",
+  "auth": "Autenticación",
+  "infinite-loading": "Carga Infinita",
+  "error-handling": "Manejo De Errores"
+}

--- a/pages/getting-started.es-ES.mdx
+++ b/pages/getting-started.es-ES.mdx
@@ -1,0 +1,219 @@
+import Callout from 'nextra-theme-docs/callout'
+import Link from 'next/link'
+
+# Comienza
+
+## Instalación
+
+Dentro del directorio de su proyecto React, ejecute lo siguiente:
+
+```
+yarn add swr
+```
+
+O con npm
+
+```
+npm install swr
+```
+
+## Inicio rápido
+
+Para APIs RESTFul normales con datos JSON, primero necesita crear una función `fethcer`, que no es más que una envoltura 
+del `fetch` nativo:
+
+```jsx
+const fetcher = (...args) => fetch(...args).then(res => res.json())
+```
+
+<Callout emoji="💡">
+    Si tu quieres usar API GraphQL o librerías como Axios, puedes crear tu propia función fetcher. Consulta
+    <Link href="/docs/data-fetching"><a href="/docs/data-fetching">aqui</a></Link> para ver más ejemplos.
+</Callout>
+
+Luego puede importar `useSWR` y empezar a usarlo dentro de cualquier componente de la función:
+
+```jsx
+import useSWR from "swr"
+
+function Profile () {
+  const { data, error } = useSWR("/api/user/123", fetcher)
+
+  if (error) return <div>failed to load</div>
+  if (!data) return <div>loading...</div>
+
+  // renderizar datos
+  return <div>hello {data.name}!</div>
+}
+```
+
+Normalmente, hay 3 estados posibles de una solicitud: "loading", "ready", o "error". Puedes utilizar el valor
+`data` y `error` para determinar el estadado actual de la solicitud, y devolver la UI correspondiente.
+
+## Hágalo reutilizable
+
+Cuando construye una aplicación web, es posible que haya que reutilizar los datos en muchos lugares de la UI.
+Es increíblemente fácil crear hooks de datos reutilizables sobre SWR:
+
+```jsx
+
+function useUser (id) {
+    const { data, error } = useSWR(`/api/user/${id}`, fetcher)
+
+    return {
+        user: data,
+        isLoading: !error && !data,
+        isError: error
+    }
+}
+
+```
+
+Y utilícelo en sus componentes:
+
+```jsx
+
+function Avatar({ id }) {
+   const { user, isLoading, isError } = useUser(id)
+
+   if(isLoading) return <Spinner />
+   if (isError) return <Error />
+   return <img src={user.avatar} />
+}
+
+```
+
+Al adoptar este patrón, puede olvidarse del **fetching** de datos de forma imperativa: inicie la solicitud,
+actualice el estado de carga, y devuelve el resultado final. En cambio, su código es más declarativo: solo hay
+que especificar qué datos utiliza el componente.
+
+## Ejemplo
+
+En un ejemplo del mundo real, nuestro sitio web muestra una barra de navegación y el contenido, 
+ambos dependen del `user`:
+
+<div className="mt-8" />
+
+<svg fill="none" viewBox="0 0 769 193">
+  <path fill="#fff" d="M0 0h768v193H0z"></path>
+  <mask id="a" width="32" height="32" x="720" y="11" maskUnits="userSpaceOnUse">
+    <circle cx="736" cy="27" r="16" fill="#fff"></circle>
+  </mask>
+  <g mask="url(#a)">
+    <circle cx="736" cy="27" r="16" fill="#EEE"></circle>
+    <circle cx="736" cy="22.9" r="6.5" fill="#C4C4C4"></circle>
+    <ellipse cx="736" cy="39.3" fill="#C4C4C4" rx="11.2" ry="7.8"></ellipse>
+  </g>
+  <path fill="#EEE" d="M15 24h186v7H15z"></path>
+  <path stroke="#EEE" d="M0 54.5h768"></path>
+  <path fill="#E5E5E5" d="M423 107h108v14H423z"></path>
+  <path
+    fill="#000"
+    d="M242.4 122h3.1l3.5-12.2h.2l3.4 12.2h3.2l4.9-17.5h-3.4l-3.2 12.9h-.1l-3.4-12.9h-3l-3.4 12.9h-.2l-3.1-12.9h-3.4l4.9 17.5zm24.8.3c3 0 5.2-1.5 5.7-3.8l-2.9-.3c-.4 1-1.4 1.7-2.7 1.7-2 0-3.4-1.4-3.4-3.6h9.1v-1c0-4.5-2.7-6.6-6-6.6-3.7 0-6.1 2.8-6.1 6.8 0 4.1 2.4 6.8 6.3 6.8zm-3.3-8c.1-1.8 1.3-3.2 3.2-3.2 1.8 0 3 1.3 3 3.1h-6.2zm14.8-9.8h-3V122h3v-17.5zm9 17.8c3.2 0 5.3-2 5.5-4.8h-3a2.6 2.6 0 01-2.6 2.2c-1.9 0-3.1-1.6-3.1-4.2 0-2.7 1.2-4.3 3.1-4.3 1.5 0 2.4 1 2.7 2.2h3c-.3-2.8-2.5-4.7-5.7-4.7-3.8 0-6.3 2.8-6.3 6.8s2.4 6.8 6.3 6.8zm13.8 0c3.8 0 6.2-2.7 6.2-6.8 0-4-2.4-6.8-6.2-6.8-3.9 0-6.3 2.7-6.3 6.8 0 4 2.4 6.8 6.3 6.8zm0-2.5c-2.1 0-3.2-2-3.2-4.3 0-2.4 1-4.3 3.2-4.3 2 0 3.1 1.9 3.1 4.3s-1 4.3-3.1 4.3zm8.9 2.2h3v-8c0-1.6 1.1-2.7 2.4-2.7 1.3 0 2.2 1 2.2 2.3v8.4h3v-8.2c0-1.4 1-2.5 2.4-2.5 1.3 0 2.3.8 2.3 2.4v8.3h3v-8.8c0-3-1.6-4.5-4-4.5-2 0-3.4 1-4 2.4h-.1c-.5-1.4-1.8-2.4-3.5-2.4-1.8 0-3.1 1-3.6 2.4h-.2V109h-3v13zm27.3.3c3 0 5.1-1.5 5.7-3.8l-2.9-.3c-.4 1-1.4 1.7-2.8 1.7-2 0-3.3-1.4-3.3-3.6h9.1v-1c0-4.5-2.8-6.6-6-6.6-3.7 0-6.2 2.8-6.2 6.8 0 4.1 2.4 6.8 6.4 6.8zm-3.3-8c0-1.8 1.3-3.2 3.2-3.2 1.7 0 3 1.3 3 3.1h-6.2zm17.8 7.7h3v-2h.2a4 4 0 003.8 2.2c3 0 5.4-2.4 5.4-6.7 0-4.4-2.4-6.8-5.4-6.8a3.9 3.9 0 00-3.8 2.4h-.1v-6.6h-3V122zm3-6.5c0-2.6 1.1-4.2 3.1-4.2s3.1 1.7 3.1 4.2c0 2.4-1 4.2-3 4.2s-3.2-1.7-3.2-4.2zm15.8 6.8c2 0 3.2-1 3.8-2.1h.1v1.8h3v-8.8c0-3.4-2.9-4.5-5.4-4.5-2.7 0-4.8 1.3-5.5 3.7l2.9.4c.3-1 1.2-1.7 2.7-1.7 1.4 0 2.2.7 2.2 2 0 1-1 1-3.3 1.2-2.5.3-5 1-5 4 0 2.6 2 4 4.5 4zm.8-2.3c-1.3 0-2.3-.6-2.3-1.7 0-1.2 1-1.7 2.5-1.9.8-.1 2.4-.3 2.8-.6v1.5c0 1.5-1.2 2.7-3 2.7zm14.9 2.3c3.3 0 5.4-2 5.6-4.8h-3a2.6 2.6 0 01-2.6 2.2c-2 0-3.2-1.6-3.2-4.2 0-2.7 1.3-4.3 3.2-4.3 1.5 0 2.4 1 2.6 2.2h3c-.2-2.8-2.4-4.7-5.6-4.7-3.9 0-6.3 2.8-6.3 6.8s2.4 6.8 6.3 6.8zm8.1-.3h3.1v-4.4l1.1-1.2 4 5.6h3.7l-5.3-7.4 5-5.7h-3.6l-4.7 5.3h-.2v-9.7h-3V122zm17.3-2.4h-2.7v1c-.2 2.3-.8 4.6-1 5.7h2c.4-1.1 1.4-3.6 1.6-5.7l.1-1z"
+  ></path>
+  <path
+    fill="#EEE"
+    fillRule="evenodd"
+    d="M5 1h758a4 4 0 014 4v173h1V5a5 5 0 00-5-5H5a5 5 0 00-5 5v173h1V5a4 4 0 014-4z"
+    clipRule="evenodd"
+  ></path>
+</svg>
+
+Tradicionalmente, obtenemos los datos una vez utilizando `useEffect` en el componente de nivel superiror, y pasarlo a los componentes hijos 
+a través de props (fíjate que por ahora no manejamos el estado de error):
+
+```jsx highlight=7,8,9,10,11,17,18,27
+// componente de la página
+
+function Page() {
+  const [user, setUser] = useState(null)
+
+  // obtener datos
+  useEffect(() => {
+    fetch("/api/user")
+      .then((res) => res.json())
+      .then((data) => setUser(data))
+  }, [])
+
+  // estado de carga global
+  if (!user) return <Spinner />
+
+  return (
+    <div>
+      <Navbar user={user} />
+      <Content user={user} />
+    </div>
+  )
+}
+
+// componentes hijos
+
+function Navbar({ user }) {
+  return (
+    <div>
+      ...
+      <Avatar user={user} />
+    </div>
+  )
+}
+
+function Content({ user }) {
+  return <h1>Welcome back, {user.name}</h1>
+}
+
+function Avatar({ user }) {
+  return <img src={user.avatar} alt={user.name} />
+}
+```
+Por lo general, necesitamos mantener todos los datos que se obtienen en el componente de nivel superiror y
+añadir las props a cada componente dentro del árbol. El código será más difícil de mantener si añadimos más 
+dependencia de datos a la página.
+
+Aunque podamos evitar pasar props usando [Context](https://reactjs.org/docs/context.html), sigue existiendo problema con el contenido dinámico:
+Los componentes dentro del contenido de la página pueden ser dinámicos, y componente de nivel superiror puede no saber qué datos necesitarán sus componentes hijos.
+
+SWR resuelve el problema perfectamente, Con el hook `useUser` que acabamos de crear, el código puede ser refactorizado a:
+
+```jsx highlight=20,26
+
+// componente de la página
+
+function Page () {
+  return <div>
+    <Navbar />
+    <Content />
+  </div>
+}
+
+// componentes hijos
+
+function Navbar() {
+   return <div>
+    ...
+    <Avatar />
+  </div>
+}
+
+function Content() {
+  const { user, isLoading } = useUser()
+  if (isLoading) return <Spinner />
+  return <h1>Welcome back, {user.name}</h1>
+}
+
+function Avatar() {
+  const { user, isLoading } = useUser()
+  if(isLoading) return <Spinner />
+  return <img src={user.avatar} alt={user.name} />
+}
+
+```
+Los datos ahora estan vinculados a los componentes que los necesitan, y todos los componentes son independientes entre sí.
+Todo los componentes padre no necesitan saber nada sobre los datos o el paso del mismo. Sólo se renderizaran. El código es mucho
+más sencillo y fácil de mantener ahora.
+
+Lo más bonito es que sólo se enviará **1 request** a la API, porque utilizan la misma clave de SWR y la solicitud se **desduplica**, 
+se almacena en **caché** y se **comparte** automáticamente.
+
+También, la aplicación tiene ahora la capacidad de volver a obtener los datos cuando [el usuario se centra o se reconecta a la red!](/docs/revalidation)
+Esto significa que, cuando el laptop del usuario se despierte de la suspeción o cambie de pestaña del navegador, los datos se actualizarán automáticamente.
+

--- a/pages/index.es-ES.mdx
+++ b/pages/index.es-ES.mdx
@@ -49,13 +49,13 @@ Con una sola línea de código, puede simplificar la obtención de datos en su p
 SWR le cubre en todos los aspectos de velocidad, correción, y estabilidad para ayudarle a construir mejores experiencias:
 
 - Navegación rápida por la página
-- Sondeo en el intervalo
+- Polling on interval
 - Dependencia de los datos
-- Revalidación sobre el enfoque
-- Revalidación en la recuperación de la red
+- Revalidation on focus
+- Revalidation on network recovery
 - Mutación local (Optimistic UI)
-- Reintento de error inteligente
-- Recuperación de la paginación y de la posición de desplazamiento
+- Smart error retry
+- Pagination and scroll position recovery
 - React Suspense
 - ...
 

--- a/pages/index.es-ES.mdx
+++ b/pages/index.es-ES.mdx
@@ -1,0 +1,73 @@
+import Callout from "nextra-theme-docs/callout";
+import Features from "components/features";
+
+# SWR
+
+<Features />
+
+El nombre “SWR” es derivado de `stale-while-revalidate`, una estrategia de invalidación de caché HTTP popularizada por [HTTP RFC 5861](https://tools.ietf.org/html/rfc5861).
+SWR es una estrategia para devolver primero los datos en caché (obsoletos), luego envíe la solicitud de recuperación (revalidación), y finalmente entrege los datos actualizados.
+
+<Callout emoji="✅">
+   Con SWR, el componente obtendrá <strong>constante</strong> y <strong>automáticamente</strong> el último flujo de datos.
+   <br />
+   Y la interfaz de usuario será siempre <strong>rápida</strong> y <strong>reactiva</strong>.
+</Callout>
+
+## Resumen
+
+```jsx
+import useSWR from 'swr'
+
+function Profile() {
+   const { data, error } = useSWR('/api/user', fetcher)
+
+   if (error) return <div>failed to load</div>
+   if (!data) return <div>loading...</div>
+   return <div>hello {data.name}!</div>
+}
+```
+
+En este ejemplo, el hook `useSWR` acepta una `key` que es un cadena y una función `fetcher`. `key` es un indentificador único de los datos (normalmente la URL de la API)
+y pasará al `fetcher`. El `fetcher` puede ser cualquier función asíncrona que devuelve datos, puedes utilizar el fetch nativo o herramientas como Axios.
+
+El hook devuelve 2 valores: `data` y `error`, basados en el estado de la solicitud.
+
+## Caracteríticas
+
+Con una sola línea de código, puede simplificar la obtención de datos en su proyecto, y tambien tiene todas estas increíbles características fuera de caja:
+
+- Orientado al **Jamstack**
+- Obtención de datos **rápida**, **ligera** y **reutilizable**
+- Caché integrada y deduplicación de solicitudes
+- Experiencia en **tiempo real**
+- Agnóstico al transporte y al protocolo
+- TypeScript ready
+- React Native
+
+
+SWR le cubre en todos los aspectos de velocidad, correción, y estabilidad para ayudarle a construir mejores experiencias:
+
+- Navegación rápida por la página
+- Sondeo en el intervalo
+- Dependencia de los datos
+- Revalidación sobre el enfoque
+- Revalidación en la recuperación de la red
+- Mutación local (Optimistic UI)
+- Reintento de error inteligente
+- Recuperación de la paginación y de la posición de desplazamiento
+- React Suspense
+- ...
+
+## Comunidad
+
+<p className="flex h-6">
+  <img alt="stars" src="https://badgen.net/github/stars/vercel/swr" className="inline-block mr-2"/>
+  <img alt="downloads" src="https://badgen.net/npm/dt/swr" className="inline-block mr-2"/>
+  <img alt="license" src="https://badgen.net/npm/license/swr" className="inline-block mr-2"/>
+</p>
+
+SWR es creado por el mismo equipo que esta detrás de [Next.js](https://nextjs.org), el framework de React.
+Sigan [@vercel](https://twitter.com/vercel) en Twitter para futuras actualizaciones del proyecto.
+
+Sientase libre de unirse a [discusiones en GitHub](https://github.com/vercel/swr/discussions)!

--- a/pages/meta.es-ES.json
+++ b/pages/meta.es-ES.json
@@ -1,0 +1,9 @@
+{
+   "index": "Introducción",
+   "getting-started": "Comienza",
+   "docs": "Documentación",
+   "advanced": "Avanzado",
+   "examples": "Ejemplos",
+   "change-log": "Registro de cambios",
+   "about": "Sobre"
+}

--- a/theme.config.js
+++ b/theme.config.js
@@ -12,7 +12,8 @@ const Vercel = ({ height = 20 }) => (
 
 const TITLE_WITH_TRANSLATIONS = {
   'en-US': 'React Hooks library for data fetching',
-  'zh-CN': '用于数据请求的 React Hooks 库'
+  'zh-CN': '用于数据请求的 React Hooks 库',
+  'es-ES': 'Biblioteca React Hooks para la obtención de datos',
 }
 
 export default {
@@ -91,6 +92,8 @@ export default {
     switch (locale) {
       case 'zh-CN':
         return '在 GitHub 上编辑本页'
+      case 'es-ES':
+        return 'Edite esta página en GitHub'
       default:
         return 'Edit this page on GitHub'
     }
@@ -101,6 +104,10 @@ export default {
         return <a href="https://vercel.com/?utm_source=swr_zh-cn" target="_blank" rel="noopener" className="inline-flex items-center no-underline text-current font-semibold">
           <span className="mr-2">由</span><span className="mr-2"><Vercel/></span>驱动
         </a>
+      case 'es-ES':
+      return <a href="https://vercel.com/?utm_source=swr_es-es" target="_blank" rel="noopener" className="inline-flex items-center no-underline text-current font-semibold">
+      <span className="mr-2">Desarrollado por</span><span className="mr-2"><Vercel/></span>
+    </a>
       default:
         return <a href="https://vercel.com/?utm_source=swr" target="_blank" rel="noopener" className="inline-flex items-center no-underline text-current font-semibold">
           <span className="mr-1">Powered by</span><span><Vercel/></span>
@@ -109,6 +116,7 @@ export default {
   },
   i18n: [
     { locale: 'en-US', text: 'English' },
+    { locale: 'es-ES', text: 'Español' },
     { locale: 'zh-CN', text: '简体中文' }
   ]
 }


### PR DESCRIPTION
This PR focuses on Spanish language support to the site. Closes #95

## Background

Spanish is ranked **number 2** of the [10 most spoken languages](https://en.wikipedia.org/wiki/List_of_languages_by_number_of_native_speakers) in the world. 

## Metrics

SWR was downloaded [1.3 million](https://yarnpkg.com/package/swr) according to yarn data in the last month, a large part of that percentage are people who speak Spanish. Although I share the idea that English is important for any developer, it is good to have the option.

## Major changes

- feat: added support for Spanish language
- doc(language): now the footer text is on Spanish
- docs(language): I18: Snpanish
- docs(language): Added metadata Spanish
- docs(language): I18 index spanish page
- docs(language): I18 Getting started to spanish
- docs(language): I18 Change log page to Spanish
- feat(I18): Add metadata related to the example to Spanish
- docs(I18): Basic use to the Spanish
- docs(I18): Auth page to Spanish
- docs(I18): Handleing error page to Spanish
- docs(I18): Inifinite loading page to Spanish
- feat(I18-spanish): added metadata related with advances section
- docs(I18): Translated to Spanish
- docs(I18): Added metadata related with documentation section
- refactor: fix typo
- docs(I18): Option translated to Spanish
- docs(I18): Configuration global page translated to Spanish
- docs(I18): Data fetching page translated to Spanish
- docs:(I18): Error handling page translated to Spanish
- refactor: Fixy typo
- docs(I18): Automatic revalidation page translated to Spanish
- docs(I18): Conditional data fetching page translated to Spanish
- docs(I18): Arguments page translated to Spanish
- docs(I18) Mutation page translated to Spanish
- docs(I18): Pagination page translated to Spanish
- docs(I18): Prefetching page translated to Spanish
- docs(I18): Usage with Next.js page translated to Spanish
- docs(I18): Suspense page translated to Spanish
- refactor: performance page
