### PR TITLE
Improves Spanish translated and little more 

### DIFF
--- a/pages/advanced/performance.es-ES.mdx
+++ b/pages/advanced/performance.es-ES.mdx
@@ -49,7 +49,7 @@ function App() {
 Cada componente `<Avatar/>` tiene un hook `useSWR` en su interior. Dado que tienen el mismo key SWR y 
 que se renderizan casi al mismo tiempo, **sólo se hará 1 solicitud de red**.
 
-Puedes reutilizar tus hooks de datos (como `useUser` en el ejemplo anterior) en todas partes, sin preocuparte por el rendimiento
+Se pueden reutilizar los hooks de datos (como `useUser` en el ejemplo anterior) en todas partes, sin preocuparse por el rendimiento
 o las peticiones duplicadas.
 
 También existe la [opción `dedupingInterval`](/docs/options) para anular el intervalo de deduplicación por defecto.
@@ -77,7 +77,7 @@ function App () {
 
 ```
 
-En el peor de los casos (la primera solicitud falló, entonces el reitento fue exitoso), verá 4 líneas de registros:
+En el peor de los casos (si la primera solicitud falló, entonces el reintento fue exitoso). Se verán 4 líneas de registros:
 
 ```js
 // console.log(data, error, isValidating)
@@ -112,11 +112,11 @@ Data      // => end retrying, get the data
 El mismo proceso ha ocurrido internamente, hubo un error de la primera solicitud, entonces tenemos los datos del reintento.
 Sin embargo, **SWR sólo actualiza los estados que utiliza el componente**, que ahora sólo es `data`.
 
-Si no utiliza siempre estos 3 estados, ya se está beneficiando de esta función. En [Vercel](https://vercel.com), esta optimización se 
+Si no se utilizan siempre estos 3 estados, ya se está beneficiando de esta función. En [Vercel](https://vercel.com), esta optimización se 
 traduce en un 60% menos de repeticiones.
 
 ## Tree Shaking
 
 El paquete SWR es [tree-shakeable](https://webpack.js.org/guides/tree-shaking) y no tiene efectos secundarios.
-Esto significa que si sólo importa `useSWR` core API, las APIs no utilizadas, como `useSWRInfinite`, no se incluirán en tu aplicación.
+Esto significa que si sólo se importa `useSWR` core API, las APIs no utilizadas, como `useSWRInfinite`, no se incluirán en la aplicación.
 

--- a/pages/advanced/performance.es-ES.mdx
+++ b/pages/advanced/performance.es-ES.mdx
@@ -62,7 +62,7 @@ activará una nueva renderización.
 También puede personalizar la función de comparación mediante la [opción `compare`](/docs/options) si quieres cambiar el comportamiento.
 Por ejemplo, algunas respuestas de la API devuelven una marca de tiempo del servidor que tal vez quiera excluir de la difusión de datos.
 
-## Coleción de dependencias
+## Colección de dependencias
 
 `useSWR` devuelve 3 valores de **estado**: `data`, `error` y `isValidating` cada uno de ellos puede actualizarse de forma independientemente.
 Por ejemplo, si imprimimos esos valores dentro de un ciclo de vida completo de obtención de datos, será algo como esto:

--- a/pages/change-log.es-ES.mdx
+++ b/pages/change-log.es-ES.mdx
@@ -22,6 +22,6 @@ Publicado en ${new Date(release.published_at) .toDateString()}.\n\n${body}`}).jo
 
 # Registro de cambios
 
-Visite [SWR release page](https://github.com/vercel/swr/releases) para ver todo el historial de lanzamientos.
+Se puede visitar [SWR release page](https://github.com/vercel/swr/releases) para ver todo el historial de lanzamientos.
 
 <ReleasesRenderer/>

--- a/theme.config.js
+++ b/theme.config.js
@@ -19,7 +19,7 @@ const TITLE_WITH_TRANSLATIONS = {
 export default {
   repository: 'https://github.com/vercel/swr',
   docsRepository: 'https://github.com/vercel/swr-site',
-  titleSuffix: '', // It was left empty with the intention of avoiding duplicated Title ---> SWR - SWR
+  titleSuffix: '', // It was left empty with the intention of avoiding duplicated title on homepage ---> SWR - SWR
   search: true,
   UNSTABLE_stork: true,
   logo: () => {

--- a/theme.config.js
+++ b/theme.config.js
@@ -19,7 +19,7 @@ const TITLE_WITH_TRANSLATIONS = {
 export default {
   repository: 'https://github.com/vercel/swr',
   docsRepository: 'https://github.com/vercel/swr-site',
-  titleSuffix: ' – SWR',
+  titleSuffix: '', // It was left empty with the intention of avoiding duplicated Title ---> SWR - SWR
   search: true,
   UNSTABLE_stork: true,
   logo: () => {


### PR DESCRIPTION
This PR focuses on improves Spanish translated, and opt use of the impersonal language. Thank You, @ernestd for the observation on typos mentioned #96.

### Bonus 😃 
 I took care of the little problem of the [duplicated title on the home page](https://github.com/vercel/swr-site/issues/82). Basically, opt to leave the value of `titleSuffix` with an empty string, my intention was to omit the property but the default value **nextra** is used title home page.

```js
export default {
  titleSuffix: ' '
  ...
}
```


Closes #82 