### PR TITLE
Fix cache name

### DIFF
--- a/pages/docs/advanced/cache.en-US.mdx
+++ b/pages/docs/advanced/cache.en-US.mdx
@@ -146,7 +146,7 @@ You might want to sync your cache to `localStorage`. Here's an example implement
 ```jsx
 function localStorageProvider() {
   // When initializing, we restore the data from `localStorage` into a map.
-  const map = new Map(JSON.parse(localStorage.getItem('swr-cache') || '[]'))
+  const map = new Map(JSON.parse(localStorage.getItem('app-cache') || '[]'))
 
   // Before unloading the app, we write back all the data into `localStorage`.
   window.addEventListener('beforeunload', () => {


### PR DESCRIPTION
I noticed the cache name was changed to `swr-cache` but only on `getItem` so I reverted to `app-cache`.