### PR TITLE
Param `fetcher` should not be optional?

### DIFF
--- a/pages/docs/options.en-US.mdx
+++ b/pages/docs/options.en-US.mdx
@@ -9,7 +9,7 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 ## Parameters
 
 - `key`: a unique key string for the request (or a function / array / null) [(advanced usage)](/docs/conditional-fetching)
-- `fetcher`: (_optional_) a Promise returning function to fetch your data [(details)](/docs/data-fetching)
+- `fetcher`: a Promise returning function to fetch your data [(details)](/docs/data-fetching)
 - `options`: (_optional_) an object of options for this SWR hook
 
 ## Return Values


### PR DESCRIPTION
As of v1.x, we need to pass our own`fetcher` params to `useSWR()` hook, don't we? 👀 

If this change make sense, I'll apply it to other languages too.