### PR TITLE
fix typo in cache.en-US.mdx

### DIFF
--- a/pages/docs/advanced/cache.en-US.mdx
+++ b/pages/docs/advanced/cache.en-US.mdx
@@ -173,7 +173,7 @@ Then use it as a provider:
 
 ### Reset Cache Between Test Cases
 
-When testing your application, you might want to reset the SWR cache between test cases. You can simply wrap you application with an empty cache provider. Here's an example with Jest:
+When testing your application, you might want to reset the SWR cache between test cases. You can simply wrap your application with an empty cache provider. Here's an example with Jest:
 
 ```jsx
 describe('test suite', async () => {


### PR DESCRIPTION
A small typo I noticed while reading the docs:

`wrap you application` > `wrap your application`