### PR TITLE
1.1.0: update the docs of object keys

### DIFF
--- a/pages/docs/arguments.en-US.md
+++ b/pages/docs/arguments.en-US.md
@@ -30,24 +30,27 @@ The function `fetchWithToken` still accepts the same 2 arguments, but the cache 
 
 ## Passing Objects
 
+import Callout from 'nextra-theme-docs/callout'
+
+<Callout>
+  Since SWR 1.1.0, object-like keys will be serialized under the hood automatically. 
+</Callout>
+  
 Say you have another function that fetches data with a user scope: `fetchWithUser(api, user)`. You can do the following:
 
 ```js
 const { data: user } = useSWR(['/api/user', token], fetchWithToken)
-// ...and pass it as an argument to another query
+
+// ...and then pass it as an argument to another useSWR hook
 const { data: orders } = useSWR(user ? ['/api/orders', user] : null, fetchWithUser)
 ```
 
-The key of the request is now the combination of both values. SWR **shallowly** compares
-the arguments on every render, and triggers revalidation if any of them has changed.  
-Keep in mind that you should not recreate objects when rendering, as they will be treated as different objects on every render:
+You can directly pass an object as the key, and `fetcher` will receive that object too:
 
 ```js
-// Don’t do this! Deps will be changed on every render.
-useSWR(['/api/user', { id }], query)
-
-// Instead, you should only pass “stable” values.
-useSWR(['/api/user', id], (url, id) => query(url, { id }))
+const { data: orders } = useSWR({ url: '/api/orders', args: user }, fetcher)
 ```
 
-Dan Abramov explains dependencies very well in [this blog post](https://overreacted.io/a-complete-guide-to-useeffect/#but-i-cant-put-this-function-inside-an-effect).
+<Callout emoji="⚠️">
+  In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed. 
+</Callout>

--- a/pages/docs/arguments.es-ES.md
+++ b/pages/docs/arguments.es-ES.md
@@ -29,8 +29,6 @@ La función `fetchWithToken` sigue aceptando los mismo 2 argumentos, pero ahora 
 
 ## Pasar objectos
 
-## Passing Objects
-
 import Callout from 'nextra-theme-docs/callout'
 
 <Callout>

--- a/pages/docs/arguments.es-ES.md
+++ b/pages/docs/arguments.es-ES.md
@@ -29,26 +29,30 @@ La función `fetchWithToken` sigue aceptando los mismo 2 argumentos, pero ahora 
 
 ## Pasar objectos
 
-Digamos que tienes otra función que obtiene datos con un scope 
-del usuario: `fetchWithUser(api, user)`. Puedes hacer lo siguiente:
+## Passing Objects
+
+import Callout from 'nextra-theme-docs/callout'
+
+<Callout>
+  Since SWR 1.1.0, object-like keys will be serialized under the hood automatically. 
+</Callout>
+  
+Say you have another function that fetches data with a user scope: `fetchWithUser(api, user)`. You can do the following:
 
 ```js
 const { data: user } = useSWR(['/api/user', token], fetchWithToken)
-// ...y pasarlo como un argumento a otra query
+
+// ...and then pass it as an argument to another useSWR hook
 const { data: orders } = useSWR(user ? ['/api/orders', user] : null, fetchWithUser)
 ```
-La `key` de la solicitud es ahora la combinación de ambos valores. SWR **shallowly** compara los argumentos en cada renderización, 
-y activa la revalidación si alguno de ellos ha cambiado.
 
-Ten en cuenta que no debes recrear los objetos al renderizar, ya que serán tratados como objetos diferentes en cada render:
+You can directly pass an object as the key, and `fetcher` will receive that object too:
 
 ```js
-// No lo hagas. Los deps se cambiarán en cada render.
-useSWR(['/api/user', { id }], query)
-
-// En su lugar, sólo debe pasar valores "estables".
-useSWR(['/api/user', id], (url, id) => query(url, { id }))
+const { data: orders } = useSWR({ url: '/api/orders', args: user }, fetcher)
 ```
 
-Dan Abramov explica muy bien las dependencias en [está entrada del blog](https://overreacted.io/a-complete-guide-to-useeffect/#but-i-cant-put-this-function-inside-an-effect).
+<Callout emoji="⚠️">
+  In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed. 
+</Callout>
 

--- a/pages/docs/arguments.ja.md
+++ b/pages/docs/arguments.ja.md
@@ -30,24 +30,30 @@ const { data: user } = useSWR(['/api/user', token], fetchWithToken)
 
 ## オブジェクトの受け渡し
 
-ユーザースコープでデータをフェッチする別の関数 `fetchWithUser(api, user)` があるとします。次のようなことができます：
+## Passing Objects
+
+import Callout from 'nextra-theme-docs/callout'
+
+<Callout>
+  Since SWR 1.1.0, object-like keys will be serialized under the hood automatically. 
+</Callout>
+  
+Say you have another function that fetches data with a user scope: `fetchWithUser(api, user)`. You can do the following:
 
 ```js
 const { data: user } = useSWR(['/api/user', token], fetchWithToken)
-// ...そして、これを引数として別のクエリに渡します
+
+// ...and then pass it as an argument to another useSWR hook
 const { data: orders } = useSWR(user ? ['/api/orders', user] : null, fetchWithUser)
 ```
 
-リクエストのキーは、両方の値の組み合わせになりました。SWR は、すべてのレンダリングで
-引数を**浅く**比較し、引数のいずれかが変更された場合は再検証を開始します。
-オブジェクトはレンダリングごとに異なるオブジェクトとして扱われるため、レンダリング時にオブジェクトを再作成しないでください。
+You can directly pass an object as the key, and `fetcher` will receive that object too:
 
 ```js
-// このようにしないでください！深さをもつオブジェクトはレンダリングごとに変更されます。
-useSWR(['/api/user', { id }], query)
-
-// 代わりに、"安定した" 値のみを渡す必要があります。
-useSWR(['/api/user', id], (url, id) => query(url, { id }))
+const { data: orders } = useSWR({ url: '/api/orders', args: user }, fetcher)
 ```
 
-Dan Abramov は、[こちらのブログ投稿](https://overreacted.io/a-complete-guide-to-useeffect/#but-i-cant-put-this-function-inside-an-effect) で依存関係について非常によく説明しています。
+<Callout emoji="⚠️">
+  In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed. 
+</Callout>
+  

--- a/pages/docs/arguments.ja.md
+++ b/pages/docs/arguments.ja.md
@@ -30,8 +30,6 @@ const { data: user } = useSWR(['/api/user', token], fetchWithToken)
 
 ## オブジェクトの受け渡し
 
-## Passing Objects
-
 import Callout from 'nextra-theme-docs/callout'
 
 <Callout>

--- a/pages/docs/arguments.ko.md
+++ b/pages/docs/arguments.ko.md
@@ -30,8 +30,6 @@ const { data: user } = useSWR(['/api/user', token], fetchWithToken)
 
 ## 객체 전달
 
-## Passing Objects
-
 import Callout from 'nextra-theme-docs/callout'
 
 <Callout>

--- a/pages/docs/arguments.ko.md
+++ b/pages/docs/arguments.ko.md
@@ -30,24 +30,29 @@ const { data: user } = useSWR(['/api/user', token], fetchWithToken)
 
 ## 객체 전달
 
-사용자 스코프를 데이터와 함께 가져오는 다른 함수가 있다고 해봅시다: `fetchWithuser(api, user)`. 다음과 같이 할 수 있습니다.
+## Passing Objects
+
+import Callout from 'nextra-theme-docs/callout'
+
+<Callout>
+  Since SWR 1.1.0, object-like keys will be serialized under the hood automatically. 
+</Callout>
+  
+Say you have another function that fetches data with a user scope: `fetchWithUser(api, user)`. You can do the following:
 
 ```js
 const { data: user } = useSWR(['/api/user', token], fetchWithToken)
-// ...그리고 이를 다른 쿼리의 인자로 전달
+
+// ...and then pass it as an argument to another useSWR hook
 const { data: orders } = useSWR(user ? ['/api/orders', user] : null, fetchWithUser)
 ```
 
-이 요청의 키는 이제 두 값의 조합입니다. SWR은 렌더링할 때마다 인자들을
-**얕게** 비교하여 변경된 것이 있으면 갱신을 트리거 합니다.
-렌더링할 때마다 객체들은 다른 객체로 취급되므로 렌더링 시에 객체를 다시 생성하지 않아야 함을 염두에 두세요.
+You can directly pass an object as the key, and `fetcher` will receive that object too:
 
 ```js
-// 이렇게 하지마세요! 의존성은 렌더링할 때마다 변경될 것입니다.
-useSWR(['/api/user', { id }], query)
-
-// 대신에 “안정적인” 값들만 전달하세요.
-useSWR(['/api/user', id], (url, id) => query(url, { id }))
+const { data: orders } = useSWR({ url: '/api/orders', args: user }, fetcher)
 ```
 
-Dan Abramov는 [이 블로그 글](https://overreacted.io/a-complete-guide-to-useeffect/#but-i-cant-put-this-function-inside-an-effect)에서 의존성에 대해 아주 잘 설명하고 있습니다.
+<Callout emoji="⚠️">
+  In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed. 
+</Callout>

--- a/pages/docs/arguments.ru.md
+++ b/pages/docs/arguments.ru.md
@@ -29,23 +29,27 @@ const { data: user } = useSWR(['/api/user', token], fetchWithToken)
 
 ## Передача объектов
 
-Скажем, у вас есть другая функция, которая извлекает данные в рамках пользователя: `fetchWithUser(api, user)`. Вы можете сделать следующее:
+import Callout from 'nextra-theme-docs/callout'
+
+<Callout>
+  Since SWR 1.1.0, object-like keys will be serialized under the hood automatically. 
+</Callout>
+  
+Say you have another function that fetches data with a user scope: `fetchWithUser(api, user)`. You can do the following:
 
 ```js
 const { data: user } = useSWR(['/api/user', token], fetchWithToken)
-// ...и передать его как аргумент другому запросу
+
+// ...and then pass it as an argument to another useSWR hook
 const { data: orders } = useSWR(user ? ['/api/orders', user] : null, fetchWithUser)
 ```
 
-Ключом запроса теперь является комбинация обоих значений. SWR **поверхностно** сравнивает аргументы на каждом рендере и запускает повторную проверку, если какой-либо из них изменился.  
-Имейте в виду, что вы не должны воссоздавать объекты при рендеринге, так как они будут обрабатываться как разные объекты при каждом рендеринге:
+You can directly pass an object as the key, and `fetcher` will receive that object too:
 
 ```js
-// Не делайте этого! Зависимости будут изменяться при каждом рендере.
-useSWR(['/api/user', { id }], query)
-
-// Вместо этого вы должны передавать только «стабильные» значения.
-useSWR(['/api/user', id], (url, id) => query(url, { id }))
+const { data: orders } = useSWR({ url: '/api/orders', args: user }, fetcher)
 ```
 
-Дэн Абрамов очень хорошо объясняет зависимости [в этом посте](https://overreacted.io/a-complete-guide-to-useeffect/#but-i-cant-put-this-function-inside-an-effect).
+<Callout emoji="⚠️">
+  In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed. 
+</Callout>


### PR DESCRIPTION
It's now safe to pass objects as the key thanks to hashing.

- [ ] Update/add the GraphQL example
- [ ] Mention that the object doesn't have to be stable