### PR TITLE
add the revalidateFirstPage option

### DIFF
--- a/pages/docs/pagination.en-US.mdx
+++ b/pages/docs/pagination.en-US.mdx
@@ -196,6 +196,7 @@ In infinite loading, one _page_ is one request, and our goal is to fetch multipl
 - `options`: accepts all the options that `useSWR` supports, with 3 extra options:
   - `initialSize = 1`: number of pages should be loaded initially
   - `revalidateAll = false`: always try to revalidate all pages
+  - `revalidateFirstPage = true`: always try to revalidate the first page
   - `persistSize = false`: don't reset the page size to 1 (or `initialSize` if set) when the first page's key changes
 
 <Callout>

--- a/pages/docs/pagination.es-ES.mdx
+++ b/pages/docs/pagination.es-ES.mdx
@@ -198,6 +198,7 @@ En la carga infinita, una _page_ es una petición, y nuestro objetivo es obtener
 - `options`: acepta todas las opciones que soporta `useSWR`, con 3 opciones adicionales:
   - `initialSize = 1`: número de páginas que deben cargarse inicialmente
   - `revalidateAll = false`: intentar siempre revalidar todas las páginas
+  - `revalidateFirstPage = true`: always try to revalidate the first page
   - `persistSize = false`: no restablecer el page size a 1 (o `initialSize` si está establecido) cuando la key de la primera página cambia
 
 <Callout>

--- a/pages/docs/pagination.ja.mdx
+++ b/pages/docs/pagination.ja.mdx
@@ -196,6 +196,7 @@ const { data, error, isValidating, mutate, size, setSize } = useSWRInfinite(
 - `options`: `useSWR` がサポートしているすべてのオプションに加えて、三つの追加オプションを受け取ります：
   - `initialSize = 1`: 最初にロードするページ数
   - `revalidateAll = false`: 常にすべてのページに対して再検証を試みる
+  - `revalidateFirstPage = true`: always try to revalidate the first page
   - `persistSize = false`: 最初のページのキーが変更されたときに、ページサイズを 1 （またはセットされていれば `initialSize`）にリセットしない
 
 <Callout>

--- a/pages/docs/pagination.ko.mdx
+++ b/pages/docs/pagination.ko.mdx
@@ -196,6 +196,7 @@ const { data, error, isValidating, mutate, size, setSize } = useSWRInfinite(
 - `options`: `useSWR`이 지원하는 모든 옵션을 받음. 세 개의 추가 옵션을 포함:
   - `initialSize = 1`: 초기에 로드해야 하는 페이지의 수
   - `revalidateAll = false`: 항상 모든 페이지의 갱신 시도
+  - `revalidateFirstPage = true`: always try to revalidate the first page
   - `persistSize = false`: 첫 페이지의 키가 변경될 때, 페이지 크기를 1(`initialSize`가 설정된 경우 `initialSize`)로 초기화하지 않음
 
 <Callout>

--- a/pages/docs/pagination.ru.mdx
+++ b/pages/docs/pagination.ru.mdx
@@ -196,6 +196,7 @@ const { data, error, isValidating, mutate, size, setSize } = useSWRInfinite(
 - `options`: принимает все опции, которые поддерживает `useSWR`, с 3 дополнительными опциями:
   - `initialSize = 1`: количество страниц, которые должны быть загружены изначально
   - `revalidateAll = false`: всегда пытаться ревалидировать все страницы
+  - `revalidateFirstPage = true`: always try to revalidate the first page
   - `persistSize = false`: не сбрасывать размер страницы до 1 (или `initialSize`, если установлен), когда ключ первой страницы изменяется
 
 <Callout>

--- a/pages/docs/pagination.zh-CN.mdx
+++ b/pages/docs/pagination.zh-CN.mdx
@@ -187,6 +187,7 @@ const { data, error, isValidating, mutate, size, setSize } = useSWRInfinite(
 - `options`: 接受 `useSWR` 支持的所有选项，以及 3 个额外选项：
   - `initialSize = 1`: 最初应加载的页面数量
   - `revalidateAll = false`: 始终尝试重新验证所有页面
+  - `revalidateFirstPage = true`: always try to revalidate the first page
   - `persistSize = false`: 当第一页的 key 发生变化时，不将 page size（或者 `initialSize` 如果设置了该参数）重置为 1
 
 <Callout>


### PR DESCRIPTION
This adds the `revalidateFirstPage` option in the document, which is added by https://github.com/vercel/swr/pull/1538.