### PR TITLE
update middleware docs after the new 1.1.0 release

### DIFF
--- a/pages/docs/middleware.en-US.md
+++ b/pages/docs/middleware.en-US.md
@@ -173,18 +173,14 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 ### Serialize Object Keys
 
-By default, SWR **shallow compares** (related topic: [Passing Objects – Arguments](/docs/arguments#passing-objects)) object keys just like React. This is powerful when you have multiple "chained" `useSWR` hooks, or using non serializable keys:
+<Callout>
+  Since SWR 1.1.0, object-like keys will be serialized under the hood automatically. 
+</Callout>
 
-```jsx
-// Hook that uses another hook's data as key
-const { data: user } = useSWR('API_CURRENT_USER', fetcher)
-const { data: userSettings } = useSWR(['API_USER_SETTINGS', user], fetcher)
-
-// Hook that uses a global function as key
-const { data: items } = useSWR([getItems], getItems)
-```
-
-However, in some cases you are just passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
+<Callout emoji="⚠️">
+  In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
+  If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
+</Callout>
 
 ```jsx
 function serialize(useSWRNext) {

--- a/pages/docs/middleware.en-US.md
+++ b/pages/docs/middleware.en-US.md
@@ -179,6 +179,7 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 <Callout emoji="⚠️">
   In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
+  <br />
   If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
 </Callout>
 

--- a/pages/docs/middleware.en-US.md
+++ b/pages/docs/middleware.en-US.md
@@ -179,7 +179,6 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 <Callout emoji="⚠️">
   In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
-  <br />
   If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
 </Callout>
 

--- a/pages/docs/middleware.ja.md
+++ b/pages/docs/middleware.ja.md
@@ -171,18 +171,14 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 ### オブジェクトキーをシリアライズする
 
-デフォルトでは、 SWR は React のように オブジェクトキーを**浅く比較**（ 関連トピック：[オブジェクトの受け渡し - 引数](/docs/arguments#オブジェクトの受け渡し) ）します。これは、複数の"チェーン"された `useSWR` がある場合、またはシリアライズできないキーを使用している場合に強力です。
+<Callout>
+  Since SWR 1.1.0, object-like keys will be serialized under the hood automatically. 
+</Callout>
 
-```jsx
-// 別のフックのデータをキーとして使用するフック
-const { data: user } = useSWR('API_CURRENT_USER', fetcher)
-const { data: userSettings } = useSWR(['API_USER_SETTINGS', user], fetcher)
-
-// グローバル関数をキーとして使用するフック
-const { data: items } = useSWR([getItems], getItems)
-```
-
-しかし、場合によってはシリアライズ可能なオブジェクトをキーとして渡すだけな時があります。その場合は、オブジェクトキーをシリアライズして安定性を確保できます。単純なミドルウェアが役立ちます：
+<Callout emoji="⚠️">
+  In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
+  If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
+</Callout>
 
 ```jsx
 function serialize(useSWRNext) {

--- a/pages/docs/middleware.ja.md
+++ b/pages/docs/middleware.ja.md
@@ -177,6 +177,7 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 <Callout emoji="⚠️">
   In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
+  <br />
   If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
 </Callout>
 

--- a/pages/docs/middleware.ja.md
+++ b/pages/docs/middleware.ja.md
@@ -177,7 +177,6 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 <Callout emoji="⚠️">
   In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
-  <br />
   If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
 </Callout>
 

--- a/pages/docs/middleware.ko.md
+++ b/pages/docs/middleware.ko.md
@@ -174,18 +174,14 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 ### 객체 키 직렬화하기
 
-기본적으로 SWR은 React와 마찬가지로 객체의 키를 **얕게 비교**(관련 주제: [객체 전달 – 인자](/docs/arguments#passing-objects))합니다. 이는 "체이닝된" `useSWR` hook이 여러 개 있거나, 직렬화할 수 없는 키를 사용하는 경우에 강력합니다.
+<Callout>
+  Since SWR 1.1.0, object-like keys will be serialized under the hood automatically. 
+</Callout>
 
-```jsx
-// 다른 hook의 데이터를 키로 사용하는 hook
-const { data: user } = useSWR('API_CURRENT_USER', fetcher)
-const { data: userSettings } = useSWR(['API_USER_SETTINGS', user], fetcher)
-
-// 전역 함수를 키로 사용하는 hook
-const { data: items } = useSWR([getItems], getItems)
-```
-
-하지만 직렬화할 수 있는 객체를 키로 전달하는 경우도 있습니다. 안정성을 보장하기 위해 객체 키를 직렬화할 수 있으며 간단한 미들웨어가 도움을 줄 수 있습니다.
+<Callout emoji="⚠️">
+  In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
+  If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
+</Callout>
 
 ```jsx
 function serialize(useSWRNext) {

--- a/pages/docs/middleware.ko.md
+++ b/pages/docs/middleware.ko.md
@@ -180,6 +180,7 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 <Callout emoji="⚠️">
   In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
+  <br />
   If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
 </Callout>
 

--- a/pages/docs/middleware.ko.md
+++ b/pages/docs/middleware.ko.md
@@ -180,7 +180,6 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 <Callout emoji="⚠️">
   In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
-  <br />
   If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
 </Callout>
 

--- a/pages/docs/middleware.ru.md
+++ b/pages/docs/middleware.ru.md
@@ -170,18 +170,14 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 ### Сериализация ключей объекта
 
-По умолчанию SWR **сравнивает поверхностно** (связанный раздел: [Передача объектов – Аргументы](/docs/arguments#передача-объектов)) ключи объектов точно так же, как React. Это эффективно, когда у вас есть несколько «связанных» хуков `useSWR` или используются несериализуемые ключи:
+<Callout>
+  Since SWR 1.1.0, object-like keys will be serialized under the hood automatically. 
+</Callout>
 
-```jsx
-// Хук, использующий в качестве ключа данные другого хука
-const { data: user } = useSWR('API_CURRENT_USER', fetcher)
-const { data: userSettings } = useSWR(['API_USER_SETTINGS', user], fetcher)
-
-// Хук, использующий в качестве ключа глобальную функцию
-const { data: items } = useSWR([getItems], getItems)
-```
-
-Однако в некоторых случаях вы просто передаёте сериализуемые объекты в качестве ключа. Вы можете сериализовать ключи объекта, чтобы обеспечить его стабильность, простое ППО может помочь:
+<Callout emoji="⚠️">
+  In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
+  If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
+</Callout>
 
 ```jsx
 function serialize(useSWRNext) {

--- a/pages/docs/middleware.ru.md
+++ b/pages/docs/middleware.ru.md
@@ -176,6 +176,7 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 <Callout emoji="⚠️">
   In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
+  <br />
   If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
 </Callout>
 

--- a/pages/docs/middleware.ru.md
+++ b/pages/docs/middleware.ru.md
@@ -176,7 +176,6 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 <Callout emoji="⚠️">
   In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
-  <br />
   If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
 </Callout>
 

--- a/pages/docs/middleware.zh-CN.md
+++ b/pages/docs/middleware.zh-CN.md
@@ -171,18 +171,14 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 ### 序列化对象 key
 
-默认情况下，SWR **浅比较**（相关主题：[传入对象 - 参数](/docs/arguments#passing-objects)）对象 key，像 React 一样。 当你有多个“链式” `useSWR` hook 或使用不可序列化 key 时，这非常强大：
+<Callout>
+  Since SWR 1.1.0, object-like keys will be serialized under the hood automatically. 
+</Callout>
 
-```jsx
-// 使用另一个 hook 的数据作为 key 的 hook
-const { data: user } = useSWR('API_CURRENT_USER', fetcher)
-const { data: userSettings } = useSWR(['API_USER_SETTINGS', user], fetcher)
-
-// 使用全局函数作为 key 的 hook
-const { data: items } = useSWR([getItems], getItems)
-```
-
-但是，在某些情况下，你只是传入可序列化的对象作为 key。你可以序列化对象 key 以确保其稳定性，一个简单的中间件可以帮助你：
+<Callout emoji="⚠️">
+  In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
+  If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
+</Callout>
 
 ```jsx
 function serialize(useSWRNext) {

--- a/pages/docs/middleware.zh-CN.md
+++ b/pages/docs/middleware.zh-CN.md
@@ -177,6 +177,7 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 <Callout emoji="⚠️">
   In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
+  <br />
   If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
 </Callout>
 

--- a/pages/docs/middleware.zh-CN.md
+++ b/pages/docs/middleware.zh-CN.md
@@ -177,7 +177,6 @@ const { data, isLagging, resetLaggy } = useSWR(key, fetcher, { use: [laggy] })
 
 <Callout emoji="⚠️">
   In older versions (< 1.1.0), SWR **shallowly** compares the arguments on every render, and triggers revalidation if any of them has changed.
-  <br />
   If you are passing serializable objects as the key. You can serialize object keys to ensure its stability, a simple middleware can help:
 </Callout>
 


### PR DESCRIPTION
Add the same callouts to the middleware section which are used in the arguments section.