### PR TITLE
docs: refreshInterval as a function

### DIFF
--- a/pages/docs/options.en-US.mdx
+++ b/pages/docs/options.en-US.mdx
@@ -27,7 +27,10 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 - `revalidateOnMount`: enable or disable automatic revalidation when component is mounted
 - `revalidateOnFocus = true`: automatically revalidate when window gets focused [(details)](/docs/revalidation)
 - `revalidateOnReconnect = true`: automatically revalidate when the browser regains a network connection (via `navigator.onLine`) [(details)](/docs/revalidation)
-- `refreshInterval = 0`: polling interval in milliseconds (disabled by default) [(details)](/docs/revalidation)
+- `refreshInterval` [(details)](/docs/revalidation): 
+  - Disabled by default: `refreshInterval = 0`
+  - If set to a number, polling interval in milliseconds 
+  - If set to a function, the function will receive the latest data and should return the interval in milliseconds
 - `refreshWhenHidden = false`: polling when the window is invisible (if `refreshInterval` is enabled)
 - `refreshWhenOffline = false`: polling when the browser is offline (determined by `navigator.onLine`)
 - `shouldRetryOnError = true`: retry when fetcher has an error

--- a/pages/docs/options.es-ES.mdx
+++ b/pages/docs/options.es-ES.mdx
@@ -29,7 +29,10 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 - `revalidateOnFocus = true`: revalidación automática cuanto window gets focused [(detalles)](/docs/revalidation)
 - `revalidateOnReconnect = true`: revalidación automática cuando el navegador recupera la conexión a la red
   (a través de `navigator.onLine`) [(detalles)](/docs/revalidation)
-- `refreshInterval = 0`: polling interval (desactivado por defecto) [(detalles)](/docs/revalidation)
+- `refreshInterval` [(detalles)](/docs/revalidation): 
+  - desactivado por defecto: `refreshInterval = 0`
+  - If set to a number, polling interval 
+  - If set to a function, the function will receive the latest data and should return the interval in milliseconds  
 - `refreshWhenHidden = false`: polling cuando window es invisible (si `refreshInterval` está activado)
 - `refreshWhenOffline = false`: polling cuando el navegador está desconectado (determinado por `navigator.onLine`)
 - `shouldRetryOnError = true`: reitentar cuando el fetcher tiene un error

--- a/pages/docs/options.ja.mdx
+++ b/pages/docs/options.ja.mdx
@@ -27,7 +27,10 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 - `revalidateOnMount`: コンポーネントのマウント時に行われる自動再検証を有効または無効にします
 - `revalidateOnFocus = true`: ウィンドウがフォーカスされたときに自動的に再検証します [（ 詳細 ）](/docs/revalidation)
 - `revalidateOnReconnect = true`: ブラウザがネットワーク接続を回復すると自動的に再検証します（ `navigator.onLine` 経由） [（ 詳細 ）](/docs/revalidation)
-- `refreshInterval = 0`: ポーリングの間隔（デフォルトでは無効） [（ 詳細 ）](/docs/revalidation)
+- `refreshInterval` [（ 詳細 ）](/docs/revalidation): 
+  - デフォルトでは無効: `refreshInterval = 0`
+  - If set to a number, ポーリングの間隔
+  - If set to a function, the function will receive the latest data and should return the interval in milliseconds
 - `refreshWhenHidden = false`: ウィンドウが非表示の場合にポーリングします（`refreshInterval` が有効になっているときのみ）
 - `refreshWhenOffline = false`: ブラウザがオフラインのときにポーリングします（`navigator.onLine` によって決定される）
 - `shouldRetryOnError = true`: フェッチャーでエラーが発生したときに再試行します

--- a/pages/docs/options.ko.mdx
+++ b/pages/docs/options.ko.mdx
@@ -27,7 +27,10 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 - `revalidateOnMount`: 컴포넌트가 마운트되었을 때 자동 갱신 활성화 또는 비활성화
 - `revalidateOnFocus = true`: 창이 포커싱되었을 때 자동 갱신 [(상세내용)](/docs/revalidation)
 - `revalidateOnReconnect = true`: 브라우저가 네트워크 연결을 다시 얻었을 때 자동으로 갱신(`navigator.onLine`을 통해) [(상세내용)](/docs/revalidation)
-- `refreshInterval = 0`: 인터벌 폴링(기본적으로는 비활성화) [(상세내용)](/docs/revalidation)
+- `refreshInterval` [(상세내용)](/docs/revalidation):
+  - 기본적으로는 비활성화: `refreshInterval = 0`
+  - If set to a number, 인터벌 폴링 
+  - If set to a function, the function will receive the latest data and should return the interval in milliseconds
 - `refreshWhenHidden = false`: 창이 보이지 않을 때 폴링(`refreshInterval`이 활성화된 경우)
 - `refreshWhenOffline = false`: 브라우저가 오프라인일 때 폴링(`navigator.onLine`에 의해 결정됨)
 - `shouldRetryOnError = true`: fetcher에 에러가 있을 때 재시도

--- a/pages/docs/options.ru.mdx
+++ b/pages/docs/options.ru.mdx
@@ -27,7 +27,10 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 - `revalidateOnMount`: включить или отключить автоматическую ревалидацию при монтировании компонента
 - `revalidateOnFocus = true`: автоматически ревалидировать, когда окно фокусируется [(подробнее)](/docs/revalidation)
 - `revalidateOnReconnect = true`: автоматически ревалидировать, когда браузер восстанавливает сетевое подключение (через `navigator.onLine`) [(подробнее)](/docs/revalidation)
-- `refreshInterval = 0`: интервал поллинга в миллисекундах (по умолчанию отключен) [(подробнее)](/docs/revalidation)
+- `refreshInterval` [(подробнее)](/docs/revalidation): 
+  - по умолчанию отключен: `refreshInterval = 0`
+  - If set to a number, интервал поллинга в миллисекундах
+  - If set to a function, the function will receive the latest data and should return the interval in milliseconds
 - `refreshWhenHidden = false`: поллинг, когда окно невидемо (если `refreshInterval` включён)
 - `refreshWhenOffline = false`: поллинг, когда браузер оффлайн (определяется `navigator.onLine`)
 - `shouldRetryOnError = true`: повторить попытку, если в fetcher-е возникла ошибка

--- a/pages/docs/options.zh-CN.mdx
+++ b/pages/docs/options.zh-CN.mdx
@@ -27,7 +27,10 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 - `revalidateOnMount`: 在挂载组件时启用或禁用自动重新验证
 - `revalidateOnFocus = true`: 窗口聚焦时自动重新验证 [（详情）](/docs/revalidation)
 - `revalidateOnReconnect = true`: 浏览器恢复网络连接时自动重新验证（通过 `navigator.onLine`） [（详情）](/docs/revalidation)
-- `refreshInterval = 0`: 轮询间隔（以毫秒为单位）（默认 disabled）[（详情）](/docs/revalidation)
+- `refreshInterval` [（详情）](/docs/revalidation): 
+  - 默认 disabled: `refreshInterval = 0`
+  - If set to a number, 轮询间隔（以毫秒为单位） 
+  - If set to a function, the function will receive the latest data and should return the interval in milliseconds
 - `refreshWhenHidden = false`: 窗口不可见时进行轮询（如果启用了 `refreshInterval`）
 - `refreshWhenOffline = false`: 浏览器离线时轮询（由 `navigator.onLine` 确定）
 - `shouldRetryOnError = true`: fetcher 有错误时重试


### PR DESCRIPTION
## Issues
Related to https://github.com/vercel/swr/pull/1690

## Description
`refreshInterval` now allows passing either a number or a function as an interval. 

I don't know how to organize this because it is the only option that has multiple forms. I'll update other languages after the English version is approved.