### PR TITLE
doc: correcting a couple of typos in TypeScript section

### DIFF
--- a/pages/docs/typescript.en-US.mdx
+++ b/pages/docs/typescript.en-US.mdx
@@ -34,10 +34,9 @@ const { data } = useSWR(uid, fetcher)
 // `data` will be `User | undefined`.
 ```
 
-
 #### useSWRInfinite
 
-Same for `swr/inifite`, you can either rely on the automatic type inference or explicitly sepicify the types by yourself.
+Same for `swr/inifite`, you can either rely on the automatic type inference or explicitly specify the types by yourself.
 
 ```typescript
 import { SWRInfiniteKeyLoader } from 'swr/infinite'
@@ -51,7 +50,7 @@ const { data } = useSWRInfinite(getKey, fetcher)
 
 ### Generics
 
-Speicifying the type of `data` is easy. By default, it will use the return type of `fetcher` (with `undefined` for the non-ready state) as the `data` type, but you can also pass it as a parameter:
+Specifying the type of `data` is easy. By default, it will use the return type of `fetcher` (with `undefined` for the non-ready state) as the `data` type, but you can also pass it as a parameter:
 
 ```typescript
 // 🔹 A. Use a typed fetcher:


### PR DESCRIPTION
Under the TypeScript docs, [`/docs/typescript`](https://swr.vercel.app/docs/typescript), I came across a couple of typos for "specify(ing)", which this PR addresses:

| Current (PROD) | After (Corrections) | 
|---|---|
| <img width="1276" alt="Screen Shot 2022-01-08 at 3 46 17 PM" src="https://user-images.githubusercontent.com/39503964/148663814-4eecdc6d-b86c-4163-a751-b5f13396be84.png"> | <img width="1319" alt="Screen Shot 2022-01-08 at 3 44 47 PM" src="https://user-images.githubusercontent.com/39503964/148663821-1bf78b07-9804-4e20-acf8-e45340d89d60.png"> | 

## Default branch name suggestion

Similarly, I would like to suggest the renaming of the SWR site's default branch from `master` to `main`, which I did on my forked version. More context here on this rename proposal, https://github.com/github/renaming. 

- If there is another avenue or step that the maintainers would like me to take for making this suggestion, just give the word. Please and thanks y'all.

