### PR TITLE
Update cache documentation link

### DIFF
--- a/pages/docs/mutation.en-US.md
+++ b/pages/docs/mutation.en-US.md
@@ -31,7 +31,7 @@ function App () {
 }
 ```
 
-*: _It broadcasts to SWR hooks under the same [cache provider](/docs/cache) scope. If no cache provider exists, it will broadcast to all SWR hooks._
+*: _It broadcasts to SWR hooks under the same [cache provider](/docs/advanced/cache) scope. If no cache provider exists, it will broadcast to all SWR hooks._
 
 ## Mutation and POST Request
 


### PR DESCRIPTION
The current cache provider link is broken and needs to be updated to the new link.