### PR TITLE
Fix cache link

### DIFF
--- a/pages/docs/global-configuration.en-US.md
+++ b/pages/docs/global-configuration.en-US.md
@@ -39,7 +39,7 @@ function App () {
 
 ### Cache Provider
 
-Besides all the [options](/docs/options) listed, `SWRConfig` also accepts an optional `provider` function. Please refer to the [Cache](/docs/cache) section for more details.
+Besides all the [options](/docs/options) listed, `SWRConfig` also accepts an optional `provider` function. Please refer to the [Cache](/docs/advanced/cache) section for more details.
 
 ```jsx
 <SWRConfig value={{ provider: () => new Map() }}>


### PR DESCRIPTION
The cache link is broken on this page. This change references the updated cache docs.