### PR TITLE
Capitalize TypeScript in translations

### DIFF
--- a/pages/docs/meta.en-US.json
+++ b/pages/docs/meta.en-US.json
@@ -11,7 +11,7 @@
   "pagination": "Pagination",
   "prefetching": "Prefetching",
   "with-nextjs": "Next.js SSG and SSR",
-  "typescript": "Typescript",
+  "typescript": "TypeScript",
   "suspense": "Suspense",
   "middleware": "Middleware",
   "advanced": "Advanced",

--- a/pages/docs/meta.es-ES.json
+++ b/pages/docs/meta.es-ES.json
@@ -11,7 +11,7 @@
   "pagination": "Paginación",
   "prefetching": "Prefetching",
   "with-nextjs": "Next.js SSG and SSR",
-  "typescript": "Typescript",
+  "typescript": "TypeScript",
   "suspense": "Suspense",
   "middleware": "Middleware",
   "advanced": "Avanzado",

--- a/pages/docs/meta.ja.json
+++ b/pages/docs/meta.ja.json
@@ -11,7 +11,7 @@
   "pagination": "ページネーション",
   "prefetching": "プリフェッチ",
   "with-nextjs": "Next.js の SSG と SSR",
-  "typescript": "Typescript",
+  "typescript": "TypeScript",
   "suspense": "サスペンス",
   "middleware": "ミドルウェア",
   "advanced": "高度な使い方",

--- a/pages/docs/meta.ko.json
+++ b/pages/docs/meta.ko.json
@@ -11,7 +11,7 @@
   "pagination": "페이지네이션",
   "prefetching": "프리패칭",
   "with-nextjs": "Next.js SSG 및 SSR",
-  "typescript": "Typescript",
+  "typescript": "TypeScript",
   "suspense": "서스펜스",
   "middleware": "Middleware",
   "advanced": "고급",

--- a/pages/docs/meta.ru.json
+++ b/pages/docs/meta.ru.json
@@ -11,7 +11,7 @@
   "pagination": "Пагинация",
   "prefetching": "Пред-выборка",
   "with-nextjs": "Next.js SSG и SSR",
-  "typescript": "Typescript",
+  "typescript": "TypeScript",
   "suspense": "Задержка (Suspense)",
   "middleware": "Промежуточное ПО (Middleware)",
   "advanced": "Продвинутые",

--- a/pages/docs/meta.zh-CN.json
+++ b/pages/docs/meta.zh-CN.json
@@ -11,7 +11,7 @@
   "pagination": "分页",
   "prefetching": "预请求",
   "with-nextjs": "Next.js SSG 和 SSR",
-  "typescript": "Typescript",
+  "typescript": "TypeScript",
   "suspense": "Suspense",
   "middleware": "中间件",
   "advanced": "高级",


### PR DESCRIPTION
This is petty, I know — I noticed that in the live site TypeScript is incorrectly capitalized as 'Typescript' in the sidebar. This PR fixes all instances of this capitalization. It's very minor but it still bugged me enough to submit this PR. Thanks for your consideration! 😄 