### PR TITLE
Fix Spanish documentation typo on the Getting started page

### DIFF
--- a/pages/docs/getting-started.es-ES.mdx
+++ b/pages/docs/getting-started.es-ES.mdx
@@ -196,4 +196,4 @@ Lo más bonito es que sólo se enviará **1 request** a la API, porque utilizan 
 se almacena en **caché** y se **comparte** automáticamente.
 
 También, la aplicación tiene ahora la capacidad de volver a obtener los datos cuando [el usuario se centra o se reconecta a la red!](/docs/revalidation)
-Esto significa que, cuando el laptop del usuario se despierte de la suspeción o cambie de pestaña del navegador, los datos se actualizarán automáticamente.
+Esto significa que, cuando el laptop del usuario se despierte de la suspensión o cambie de pestaña del navegador, los datos se actualizarán automáticamente.


### PR DESCRIPTION
I have detected a typo on the word "suspeción" (It doesn't exist) and changed it to "suspensión". I think that's the word that was meant to be used.