### PR TITLE
fix: import statement in the TypeScript example

### DIFF
--- a/pages/docs/typescript.en-US.mdx
+++ b/pages/docs/typescript.en-US.mdx
@@ -65,7 +65,7 @@ const { data } = useSWR<User>('/api/user', fetcher)
 If you want to add types for other options of SWR, you can also import those types directly:
 
 ```typescript
-import { useSWR } from 'swr'
+import useSWR from 'swr'
 import type { SWRConfiguration } from 'swr'
 
 const config: SWRConfiguration = {

--- a/pages/docs/typescript.es-ES.mdx
+++ b/pages/docs/typescript.es-ES.mdx
@@ -65,7 +65,7 @@ const { data } = useSWR<User>('/api/user', fetcher)
 If you want to add types for other options of SWR, you can also import those types directly:
 
 ```typescript
-import { useSWR } from 'swr'
+import useSWR from 'swr'
 import type { SWRConfiguration } from 'swr'
 
 const config: SWRConfiguration = {

--- a/pages/docs/typescript.ja.mdx
+++ b/pages/docs/typescript.ja.mdx
@@ -65,7 +65,7 @@ const { data } = useSWR<User>('/api/user', fetcher)
 SWR オプションの型を追加したい場合は、これらの型を直接インポートすることもできます：
 
 ```typescript
-import { useSWR } from 'swr'
+import useSWR from 'swr'
 import type { SWRConfiguration } from 'swr'
 
 const config: SWRConfiguration = {

--- a/pages/docs/typescript.ko.mdx
+++ b/pages/docs/typescript.ko.mdx
@@ -65,7 +65,7 @@ const { data } = useSWR<User>('/api/user', fetcher)
 If you want to add types for other options of SWR, you can also import those types directly:
 
 ```typescript
-import { useSWR } from 'swr'
+import useSWR from 'swr'
 import type { SWRConfiguration } from 'swr'
 
 const config: SWRConfiguration = {

--- a/pages/docs/typescript.ru.mdx
+++ b/pages/docs/typescript.ru.mdx
@@ -65,7 +65,7 @@ const { data } = useSWR<User>('/api/user', fetcher)
 If you want to add types for other options of SWR, you can also import those types directly:
 
 ```typescript
-import { useSWR } from 'swr'
+import useSWR from 'swr'
 import type { SWRConfiguration } from 'swr'
 
 const config: SWRConfiguration = {

--- a/pages/docs/typescript.zh-CN.mdx
+++ b/pages/docs/typescript.zh-CN.mdx
@@ -65,7 +65,7 @@ const { data } = useSWR<User>('/api/user', fetcher)
 如果要为 SWR 的其他选项添加类型，你也可以直接导入这些类型：
 
 ```typescript
-import { useSWR } from 'swr'
+import useSWR from 'swr'
 import type { SWRConfiguration } from 'swr'
 
 const config: SWRConfiguration = {


### PR DESCRIPTION
fixes #258 
The import statement should be a default import instead of a named import.
