### PR TITLE
Fix optimistic update example

### DIFF
--- a/pages/docs/mutation.en-US.md
+++ b/pages/docs/mutation.en-US.md
@@ -59,7 +59,7 @@ function Profile () {
         // updates the local data immediately
         // send a request to update the data
         // triggers a revalidation (refetch) to make sure our local data is correct
-        mutate(updateFn(user), options);
+        mutate('/api/user', updateFn(user), options);
       }}>Uppercase my name!</button>
     </div>
   )


### PR DESCRIPTION
The optimistic update example needs the key passed as the first param of the (config) mutate function, or use the bound mutate function (as it is done in the [example](https://codesandbox.io/embed/swr-basic-forked-k5hps?fontsize=14&hidenavigation=1&theme=dark)). 

Note: I checked the other language files but they don't seem to have this example.