### PR TITLE
docs: fix broken link to cache

### DIFF
--- a/pages/docs/global-configuration.ja.md
+++ b/pages/docs/global-configuration.ja.md
@@ -39,7 +39,7 @@ function App () {
 
 ### キャッシュプロバイダー
 
-紹介されているすべてのオプションに加えて、 `SWRConfig` または `provider` 関数も受け入れます。詳細は[キャッシュ](/docs/cache)セクションを参照してください。
+紹介されているすべてのオプションに加えて、 `SWRConfig` または `provider` 関数も受け入れます。詳細は[キャッシュ](/docs/advanced/cache)セクションを参照してください。
 
 ```jsx
 <SWRConfig value={{ provider: () => new Map() }}>


### PR DESCRIPTION
This PR is fix broken link to cache.
in global-configuration.ja.md
