### PR TITLE
doc: Add TypeScript error type info

### DIFF
--- a/pages/docs/typescript.en-US.mdx
+++ b/pages/docs/typescript.en-US.mdx
@@ -34,6 +34,14 @@ const { data } = useSWR(uid, fetcher)
 // `data` will be `User | undefined`.
 ```
 
+By default, [the error thrown](/docs/error-handling) inside the `fetcher` function has type `any`. The type can also explicitly specified.
+
+```typescript
+const { data, error } = useSWR<User, Error>(uid, fetcher);
+// `data` will be `User | undefined`.
+// `error` will be `Error | undefined`.
+```
+
 ### useSWRInfinite
 
 Same for `swr/infinite`, you can either rely on the automatic type inference or explicitly specify the types by yourself.

--- a/pages/docs/typescript.es-ES.mdx
+++ b/pages/docs/typescript.es-ES.mdx
@@ -34,9 +34,17 @@ const { data } = useSWR(uid, fetcher)
 // `data` will be `User | undefined`.
 ```
 
+By default, [the error thrown](/docs/error-handling) inside the `fetcher` function has type `any`. The type can also explicitly specified.
+
+```typescript
+const { data, error } = useSWR<User, Error>(uid, fetcher);
+// `data` will be `User | undefined`.
+// `error` will be `Error | undefined`.
+```
+
 ### useSWRInfinite
 
-Same for `swr/inifite`, you can either rely on the automatic type inference or explicitly specify the types by yourself.
+Same for `swr/infinite`, you can either rely on the automatic type inference or explicitly specify the types by yourself.
 
 ```typescript
 import { SWRInfiniteKeyLoader } from 'swr/infinite'

--- a/pages/docs/typescript.ja.mdx
+++ b/pages/docs/typescript.ja.mdx
@@ -34,6 +34,14 @@ const { data } = useSWR(uid, fetcher)
 // `data` は `User | undefined` となります。
 ```
 
+By default, [the error thrown](/docs/error-handling) inside the `fetcher` function has type `any`. The type can also explicitly specified.
+
+```typescript
+const { data, error } = useSWR<User, Error>(uid, fetcher);
+// `data` will be `User | undefined`.
+// `error` will be `Error | undefined`.
+```
+
 ### useSWRInfinite
 
 `swr/infinite` の場合と同じように、型推論に頼るか、自分で明示的に型を指定することができます。

--- a/pages/docs/typescript.ko.mdx
+++ b/pages/docs/typescript.ko.mdx
@@ -34,9 +34,17 @@ const { data } = useSWR(uid, fetcher)
 // `data` will be `User | undefined`.
 ```
 
+By default, [the error thrown](/docs/error-handling) inside the `fetcher` function has type `any`. The type can also explicitly specified.
+
+```typescript
+const { data, error } = useSWR<User, Error>(uid, fetcher);
+// `data` will be `User | undefined`.
+// `error` will be `Error | undefined`.
+```
+
 ### useSWRInfinite
 
-Same for `swr/inifite`, you can either rely on the automatic type inference or explicitly specify the types by yourself.
+Same for `swr/infinite`, you can either rely on the automatic type inference or explicitly specify the types by yourself.
 
 ```typescript
 import { SWRInfiniteKeyLoader } from 'swr/infinite'

--- a/pages/docs/typescript.ru.mdx
+++ b/pages/docs/typescript.ru.mdx
@@ -35,9 +35,17 @@ const { data } = useSWR(uid, fetcher)
 // `data` будет `User | undefined`.
 ```
 
+By default, [the error thrown](/docs/error-handling) inside the `fetcher` function has type `any`. The type can also explicitly specified.
+
+```typescript
+const { data, error } = useSWR<User, Error>(uid, fetcher);
+// `data` will be `User | undefined`.
+// `error` will be `Error | undefined`.
+```
+
 ### useSWRInfinite
 
-То же самое для `swr/inifite`, вы можете либо полагаться на автоматический вывод типа, либо явно указывать типы самостоятельно.
+То же самое для `swr/infinite`, вы можете либо полагаться на автоматический вывод типа, либо явно указывать типы самостоятельно.
 
 ```typescript
 import { SWRInfiniteKeyLoader } from 'swr/infinite'

--- a/pages/docs/typescript.zh-CN.mdx
+++ b/pages/docs/typescript.zh-CN.mdx
@@ -34,9 +34,17 @@ const { data } = useSWR(uid, fetcher)
 // `data` 将会是 `User | undefined`.
 ```
 
+By default, [the error thrown](/docs/error-handling) inside the `fetcher` function has type `any`. The type can also explicitly specified.
+
+```typescript
+const { data, error } = useSWR<User, Error>(uid, fetcher);
+// `data` will be `User | undefined`.
+// `error` will be `Error | undefined`.
+```
+
 ### useSWRInfinite
 
-同样适用于 `swr/inifite`，你可以依靠自动类型推断或自己显式地指定类型。
+同样适用于 `swr/infinite`，你可以依靠自动类型推断或自己显式地指定类型。
 
 ```typescript
 import { SWRInfiniteKeyLoader } from 'swr/infinite'


### PR DESCRIPTION
Add example how to specify the `useSWR` error type in TypeScript. Fix also typo in swr/inifite.