### PR TITLE
Clarifying the limitations of deep comparison in the advanced performance docs

### DIFF
--- a/pages/docs/advanced/performance.en-US.mdx
+++ b/pages/docs/advanced/performance.en-US.mdx
@@ -50,7 +50,8 @@ There is also a [`dedupingInterval` option](/docs/options) for overriding the de
 
 ## Deep Comparison
 
-SWR **deep compares** data changes by default. If the `data` value isn’t changed, a re-render will not be triggered.
+SWR **deep compares** data changes by default (with some limitations - for objects where the constructor is not `Object` like Sets and Maps, referential equality is used. See [stable-hash](https://github.com/shuding/stable-hash) for more details).
+If the `data` value isn’t changed, a re-render will not be triggered.
 
 You can also customize the comparison function via the [`compare` option](/docs/options) if you want to change the behavior.
 For example, some API responses return a server timestamp that you might want to exclude from the data diff.

--- a/pages/docs/advanced/performance.es-ES.mdx
+++ b/pages/docs/advanced/performance.es-ES.mdx
@@ -56,7 +56,7 @@ También existe la [opción `dedupingInterval`](/docs/options) para anular el in
 
 ## Comparación profunda
 
-SWR por defecto tiene  **deep compares** al cambio de datos. Si el valor de `data` no ha cambiado, no se
+SWR por defecto tiene  **deep compares** al cambio de datos (with some limitations - for objects where the constructor is not `Object` like Sets and Maps, referential equality is used. See [stable-hash](https://github.com/shuding/stable-hash) for more details). Si el valor de `data` no ha cambiado, no se
 activará una nueva renderización.
 
 También puede personalizar la función de comparación mediante la [opción `compare`](/docs/options) si quieres cambiar el comportamiento.

--- a/pages/docs/advanced/performance.ja.mdx
+++ b/pages/docs/advanced/performance.ja.mdx
@@ -55,6 +55,8 @@ SWR は、デフォルトでデータの変更を**詳細に比較**します。
 動作を変更したい場合は、[`compare` オプション](/docs/options)を使用して比較機能をカスタマイズすることもできます。
 たとえば、一部の API レスポンスは、データ差分から除外したいサーバーのタイムスタンプを返します。
 
+(with some limitations - for objects where the constructor is not `Object` like Sets and Maps, referential equality is used. See [stable-hash](https://github.com/shuding/stable-hash) for more details)
+
 ## 依存関係のコレクション
 
 `useSWR` が返す三つの**ステートフルな**値、つまり `data` 、`error` 、そして `isValidating` は、それぞれが独立して更新されます。

--- a/pages/docs/advanced/performance.ko.mdx
+++ b/pages/docs/advanced/performance.ko.mdx
@@ -54,6 +54,8 @@ SWR은 기본적으로 데이터 변경을 **깊게 비교**합니다. `data` �
 이 동작을 변경하길 원한다면 [`compare` 옵션](/docs/options)을 통해 비교 함수를 커스터마이징할 수도 있습니다.
 예를 들면, 일부 API의 응답이 데이터 diff에서 제외하길 원하는 서버의 타임 스탬프를 반환합니다.
 
+(with some limitations - for objects where the constructor is not `Object` like Sets and Maps, referential equality is used. See [stable-hash](https://github.com/shuding/stable-hash) for more details)
+
 ## 의존성 수집
 
 `useSWR`은 세 개의 **스테이트풀** 값을 반환합니다: `data`, `error`, `isValidating`, 각각은 독립적으로 업데이트됩니다.

--- a/pages/docs/advanced/performance.pt-BR.mdx
+++ b/pages/docs/advanced/performance.pt-BR.mdx
@@ -50,7 +50,7 @@ Há também uma [opção `dedupingInterval`](/docs/options) para substituir o in
 
 ## Comparação Profunda
 
-SWR **compara profundamente** as mudanças de dados por padrão. Se o valor `data` não é alterado, uma re-renderização não será acionada.
+SWR **compara profundamente** as mudanças de dados por padrão (with some limitations - for objects where the constructor is not `Object` like Sets and Maps, referential equality is used. See [stable-hash](https://github.com/shuding/stable-hash) for more details). Se o valor `data` não é alterado, uma re-renderização não será acionada.
 
 Você também pode customizar a função de comparação via opção [`compare`](/docs/options) se você quiser mudar o comportamento.
 Por exemplo, alguns respostas de API retornam um timestamp do servidor que você pode querer excluir do diff de dados.

--- a/pages/docs/advanced/performance.ru.mdx
+++ b/pages/docs/advanced/performance.ru.mdx
@@ -56,7 +56,7 @@ function App () {
 
 ## Глубокое сравнение
 
-SWR **глубоко сравнивает** изменения данных по умолчанию. Если значение `data` не изменилось,
+SWR **глубоко сравнивает** изменения данных по умолчанию (with some limitations - for objects where the constructor is not `Object` like Sets and Maps, referential equality is used. See [stable-hash](https://github.com/shuding/stable-hash) for more details). Если значение `data` не изменилось,
 повторный рендеринг запускаться не будет.
 
 Вы также можете настроить функцию сравнения с помощью [опции `compare`](/docs/options), если хотите

--- a/pages/docs/advanced/performance.zh-CN.mdx
+++ b/pages/docs/advanced/performance.zh-CN.mdx
@@ -51,6 +51,7 @@ function App () {
 SWR 默认 **深度比较** 数据更改。如果 `data` 值没有改变，则不会触发重新渲染。
 
 如果你还想更改的话，可以通过 [`compare` 选项](/docs/options) 自定义比较函数。比如，某些 API 响应返回一个服务器时间戳，你可能想从数据 diff 中排除它。
+(with some limitations - for objects where the constructor is not `Object` like Sets and Maps, referential equality is used. See [stable-hash](https://github.com/shuding/stable-hash) for more details)
 
 ## 依赖收集
 


### PR DESCRIPTION
### Description
To my knowledge (which very well may be wrong!), useSWR uses stable-hash for deep comparisons.  

If so, then I think this change is helpful for some of those cases where it'll be a reference comparison.

Thanks for all your hard work on this library!

<!-- What're you changing? -->

- [ ] Adding new page
- [X] Updating existing documentation
- [ ] Other updates


