### PR TITLE
typo fix getKey example

### DIFF
--- a/pages/docs/pagination.en-US.mdx
+++ b/pages/docs/pagination.en-US.mdx
@@ -303,7 +303,7 @@ We can change our `getKey` function to:
 ```jsx
 const getKey = (pageIndex, previousPageData) => {
   // reached the end
-  if (previousPageData && !previousPageData.data) return null
+  if (previousPageData && !previousPageData.length) return null
 
   // first page, we don't have `previousPageData`
   if (pageIndex === 0) return `/users?limit=10`


### PR DESCRIPTION
fix reached the end detection using `previousPageData.length`

