### PR TITLE
docs: SWRConfig value as a function

### DIFF
--- a/pages/docs/global-configuration.en-US.md
+++ b/pages/docs/global-configuration.en-US.md
@@ -37,7 +37,9 @@ function App () {
 
 ## Nesting Configurations
 
-`SWRConfig` merges the configuration from the parent context.
+`SWRConfig` merges the configuration from the parent context. It can receive either an object or a functional configuration. The functional one receives the parent configuration as argument and returns a new configuration that you can customize it yourself. 
+
+### Object Configuration Example
 
 ```jsx
 import { SWRConfig, useSWRConfig } from 'swr'
@@ -54,7 +56,7 @@ function App() {
       <SWRConfig
         value={{
           dedupingInterval: 200, // override the parent value
-          fallback: { a: 2, c: 2 }, // merge with the parent value
+          fallback: { a: 2, c: 2 }, // will merge with the parent value since the value is a mergeable object
         }}
       >
         <Page />
@@ -73,7 +75,7 @@ function Page() {
 }
 ```
 
-You can also pass a function as the `value` property when you want to pick some properties from the parent context and decide how to combine them with the current `SWRConfig`. The function receives a parent config and returns a new config.
+### Functional Configuration Example
 
 ```jsx
 import { SWRConfig, useSWRConfig } from 'swr'

--- a/pages/docs/global-configuration.en-US.md
+++ b/pages/docs/global-configuration.en-US.md
@@ -35,6 +35,79 @@ function App () {
 }
 ```
 
+## Nesting Configurations
+
+`SWRConfig` merges the configuration from the parent context.
+
+```jsx
+import { SWRConfig, useSWRConfig } from 'swr'
+
+function App() {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 100,
+        refreshInterval: 100,
+        fallback: { a: 1, b: 1 },
+      }}
+    >
+      <SWRConfig
+        value={{
+          dedupingInterval: 200, // override the parent value
+          fallback: { a: 2, c: 2 }, // merge with the parent value
+        }}
+      >
+        <Page />
+      </SWRConfig>
+    </SWRConfig>
+  )
+}
+
+function Page() {
+  const config = useSWRConfig()
+  // {
+  //   dedupingInterval: 200,
+  //   refreshInterval: 100,
+  //   fallback: { a: 2,  b: 1, c: 2 },
+  // }
+}
+```
+
+You can also pass a function as the `value` property when you want to pick some properties from the parent context and decide how to combine them with the current `SWRConfig`. The function receives a parent config and returns a new config.
+
+```jsx
+import { SWRConfig, useSWRConfig } from 'swr'
+
+function App() {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 100,
+        refreshInterval: 100,
+        fallback: { a: 1, b: 1 },
+      }}
+    >
+      <SWRConfig
+        value={parent => ({
+          dedupingInterval: parent.dedupingInterval * 5,
+          fallback: { a: 2, c: 2 },
+        })}
+      >
+        <Page />
+      </SWRConfig>
+    </SWRConfig>
+  )
+}
+
+function Page() {
+  const config = useSWRConfig()
+  // {
+  //   dedupingInterval: 500,
+  //   fallback: { a: 2, c: 2 },
+  // }
+}
+```
+
 ## Extra APIs
 
 ### Cache Provider

--- a/pages/docs/global-configuration.en-US.md
+++ b/pages/docs/global-configuration.en-US.md
@@ -55,7 +55,7 @@ function App() {
     >
       <SWRConfig
         value={{
-          dedupingInterval: 200, // override the parent value
+          dedupingInterval: 200, // will override the parent value since the value is primitive
           fallback: { a: 2, c: 2 }, // will merge with the parent value since the value is a mergeable object
         }}
       >

--- a/pages/docs/global-configuration.es-ES.md
+++ b/pages/docs/global-configuration.es-ES.md
@@ -36,6 +36,79 @@ function App () {
 }
 ```
 
+## Nesting Configurations
+
+`SWRConfig` merges the configuration from the parent context.
+
+```jsx
+import { SWRConfig, useSWRConfig } from 'swr'
+
+function App() {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 100,
+        refreshInterval: 100,
+        fallback: { a: 1, b: 1 },
+      }}
+    >
+      <SWRConfig
+        value={{
+          dedupingInterval: 200, // override the parent value
+          fallback: { a: 2, c: 2 }, // merge with the parent value
+        }}
+      >
+        <Page />
+      </SWRConfig>
+    </SWRConfig>
+  )
+}
+
+function Page() {
+  const config = useSWRConfig()
+  // {
+  //   dedupingInterval: 200,
+  //   refreshInterval: 100,
+  //   fallback: { a: 2,  b: 1, c: 2 },
+  // }
+}
+```
+
+You can also pass a function as the `value` property when you want to pick some properties from the parent context and decide how to combine them with the current `SWRConfig`. The function receives a parent config and returns a new config.
+
+```jsx
+import { SWRConfig, useSWRConfig } from 'swr'
+
+function App() {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 100,
+        refreshInterval: 100,
+        fallback: { a: 1, b: 1 },
+      }}
+    >
+      <SWRConfig
+        value={parent => ({
+          dedupingInterval: parent.dedupingInterval * 5,
+          fallback: { a: 2, c: 2 },
+        })}
+      >
+        <Page />
+      </SWRConfig>
+    </SWRConfig>
+  )
+}
+
+function Page() {
+  const config = useSWRConfig()
+  // {
+  //   dedupingInterval: 500,
+  //   fallback: { a: 2, c: 2 },
+  // }
+}
+```
+
 ## Extra APIs
 
 ### Cache Provider

--- a/pages/docs/global-configuration.es-ES.md
+++ b/pages/docs/global-configuration.es-ES.md
@@ -38,7 +38,9 @@ function App () {
 
 ## Nesting Configurations
 
-`SWRConfig` merges the configuration from the parent context.
+`SWRConfig` merges the configuration from the parent context. It can receive either an object or a functional configuration. The functional one receives the parent configuration as argument and returns a new configuration that you can customize it yourself. 
+
+### Object Configuration Example
 
 ```jsx
 import { SWRConfig, useSWRConfig } from 'swr'
@@ -54,8 +56,8 @@ function App() {
     >
       <SWRConfig
         value={{
-          dedupingInterval: 200, // override the parent value
-          fallback: { a: 2, c: 2 }, // merge with the parent value
+          dedupingInterval: 200, // will override the parent value since the value is primitive
+          fallback: { a: 2, c: 2 }, // will merge with the parent value since the value is a mergeable object
         }}
       >
         <Page />
@@ -74,7 +76,7 @@ function Page() {
 }
 ```
 
-You can also pass a function as the `value` property when you want to pick some properties from the parent context and decide how to combine them with the current `SWRConfig`. The function receives a parent config and returns a new config.
+### Functional Configuration Example
 
 ```jsx
 import { SWRConfig, useSWRConfig } from 'swr'

--- a/pages/docs/global-configuration.ja.md
+++ b/pages/docs/global-configuration.ja.md
@@ -35,6 +35,79 @@ function App () {
 }
 ```
 
+## ネストした設定
+
+`SWRConfig` は親で指定された設定をマージします。
+
+```jsx
+import { SWRConfig, useSWRConfig } from 'swr'
+
+function App() {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 100,
+        refreshInterval: 100,
+        fallback: { a: 1, b: 1 },
+      }}
+    >
+      <SWRConfig
+        value={{
+          dedupingInterval: 200, // 親から渡された値を上書き
+          fallback: { a: 2, c: 2 }, // 親から受け取った値とマージ
+        }}
+      >
+        <Page />
+      </SWRConfig>
+    </SWRConfig>
+  )
+}
+
+function Page() {
+  const config = useSWRConfig()
+  // {
+  //   dedupingInterval: 200,
+  //   refreshInterval: 100,
+  //   fallback: { a: 2,  b: 1, c: 2 },
+  // }
+}
+```
+
+親から受け取ったプロパティをそのままマージするのではなく、それを組み合わせて新しい設定を作りたい場合には、`SWRConfig` の `value` プロパティに関数を渡すことで実現できます。関数は親で指定された設定を受け取り新しい設定を返します。
+
+```jsx
+import { SWRConfig, useSWRConfig } from 'swr'
+
+function App() {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 100,
+        refreshInterval: 100,
+        fallback: { a: 1, b: 1 },
+      }}
+    >
+      <SWRConfig
+        value={parent => ({
+          dedupingInterval: parent.dedupingInterval * 5,
+          fallback: { a: 2, c: 2 },
+        })}
+      >
+        <Page />
+      </SWRConfig>
+    </SWRConfig>
+  )
+}
+
+function Page() {
+  const config = useSWRConfig()
+  // {
+  //   dedupingInterval: 500,
+  //   fallback: { a: 2, c: 2 },
+  // }
+}
+```
+
 ## Extra APIs
 
 ### キャッシュプロバイダー

--- a/pages/docs/global-configuration.ja.md
+++ b/pages/docs/global-configuration.ja.md
@@ -37,7 +37,7 @@ function App () {
 
 ## ネストした設定
 
-`SWRConfig` は親で指定された設定をマージします。
+`SWRConfig` は親で指定された設定をマージします。設定はオブジェクトまたは関数として受け取ることができます。関数の場合、親の設定を引数として受け取り新しくカスタマイズした設定を返します。
 
 ```jsx
 import { SWRConfig, useSWRConfig } from 'swr'
@@ -53,8 +53,8 @@ function App() {
     >
       <SWRConfig
         value={{
-          dedupingInterval: 200, // 親から渡された値を上書き
-          fallback: { a: 2, c: 2 }, // 親から受け取った値とマージ
+          dedupingInterval: 200, // これはプリミティブ値であるため親の値を上書きします
+          fallback: { a: 2, c: 2 }, // これはマージ可能なオブジェクトであるため親から受け取った値とマージします
         }}
       >
         <Page />
@@ -73,7 +73,6 @@ function Page() {
 }
 ```
 
-親から受け取ったプロパティをそのままマージするのではなく、それを組み合わせて新しい設定を作りたい場合には、`SWRConfig` の `value` プロパティに関数を渡すことで実現できます。関数は親で指定された設定を受け取り新しい設定を返します。
 
 ```jsx
 import { SWRConfig, useSWRConfig } from 'swr'

--- a/pages/docs/global-configuration.ko.md
+++ b/pages/docs/global-configuration.ko.md
@@ -37,7 +37,9 @@ function App () {
 
 ## Nesting Configurations
 
-`SWRConfig` merges the configuration from the parent context.
+`SWRConfig` merges the configuration from the parent context. It can receive either an object or a functional configuration. The functional one receives the parent configuration as argument and returns a new configuration that you can customize it yourself. 
+
+### Object Configuration Example
 
 ```jsx
 import { SWRConfig, useSWRConfig } from 'swr'
@@ -53,8 +55,8 @@ function App() {
     >
       <SWRConfig
         value={{
-          dedupingInterval: 200, // override the parent value
-          fallback: { a: 2, c: 2 }, // merge with the parent value
+          dedupingInterval: 200, // will override the parent value since the value is primitive
+          fallback: { a: 2, c: 2 }, // will merge with the parent value since the value is a mergeable object
         }}
       >
         <Page />
@@ -73,7 +75,7 @@ function Page() {
 }
 ```
 
-You can also pass a function as the `value` property when you want to pick some properties from the parent context and decide how to combine them with the current `SWRConfig`. The function receives a parent config and returns a new config.
+### Functional Configuration Example
 
 ```jsx
 import { SWRConfig, useSWRConfig } from 'swr'

--- a/pages/docs/global-configuration.ko.md
+++ b/pages/docs/global-configuration.ko.md
@@ -35,6 +35,79 @@ function App () {
 }
 ```
 
+## Nesting Configurations
+
+`SWRConfig` merges the configuration from the parent context.
+
+```jsx
+import { SWRConfig, useSWRConfig } from 'swr'
+
+function App() {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 100,
+        refreshInterval: 100,
+        fallback: { a: 1, b: 1 },
+      }}
+    >
+      <SWRConfig
+        value={{
+          dedupingInterval: 200, // override the parent value
+          fallback: { a: 2, c: 2 }, // merge with the parent value
+        }}
+      >
+        <Page />
+      </SWRConfig>
+    </SWRConfig>
+  )
+}
+
+function Page() {
+  const config = useSWRConfig()
+  // {
+  //   dedupingInterval: 200,
+  //   refreshInterval: 100,
+  //   fallback: { a: 2,  b: 1, c: 2 },
+  // }
+}
+```
+
+You can also pass a function as the `value` property when you want to pick some properties from the parent context and decide how to combine them with the current `SWRConfig`. The function receives a parent config and returns a new config.
+
+```jsx
+import { SWRConfig, useSWRConfig } from 'swr'
+
+function App() {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 100,
+        refreshInterval: 100,
+        fallback: { a: 1, b: 1 },
+      }}
+    >
+      <SWRConfig
+        value={parent => ({
+          dedupingInterval: parent.dedupingInterval * 5,
+          fallback: { a: 2, c: 2 },
+        })}
+      >
+        <Page />
+      </SWRConfig>
+    </SWRConfig>
+  )
+}
+
+function Page() {
+  const config = useSWRConfig()
+  // {
+  //   dedupingInterval: 500,
+  //   fallback: { a: 2, c: 2 },
+  // }
+}
+```
+
 ## 부가적인 APIs
 
 ### 캐시 공급자

--- a/pages/docs/global-configuration.pt-BR.md
+++ b/pages/docs/global-configuration.pt-BR.md
@@ -35,6 +35,79 @@ function App () {
 }
 ```
 
+## Nesting Configurations
+
+`SWRConfig` merges the configuration from the parent context.
+
+```jsx
+import { SWRConfig, useSWRConfig } from 'swr'
+
+function App() {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 100,
+        refreshInterval: 100,
+        fallback: { a: 1, b: 1 },
+      }}
+    >
+      <SWRConfig
+        value={{
+          dedupingInterval: 200, // override the parent value
+          fallback: { a: 2, c: 2 }, // merge with the parent value
+        }}
+      >
+        <Page />
+      </SWRConfig>
+    </SWRConfig>
+  )
+}
+
+function Page() {
+  const config = useSWRConfig()
+  // {
+  //   dedupingInterval: 200,
+  //   refreshInterval: 100,
+  //   fallback: { a: 2,  b: 1, c: 2 },
+  // }
+}
+```
+
+You can also pass a function as the `value` property when you want to pick some properties from the parent context and decide how to combine them with the current `SWRConfig`. The function receives a parent config and returns a new config.
+
+```jsx
+import { SWRConfig, useSWRConfig } from 'swr'
+
+function App() {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 100,
+        refreshInterval: 100,
+        fallback: { a: 1, b: 1 },
+      }}
+    >
+      <SWRConfig
+        value={parent => ({
+          dedupingInterval: parent.dedupingInterval * 5,
+          fallback: { a: 2, c: 2 },
+        })}
+      >
+        <Page />
+      </SWRConfig>
+    </SWRConfig>
+  )
+}
+
+function Page() {
+  const config = useSWRConfig()
+  // {
+  //   dedupingInterval: 500,
+  //   fallback: { a: 2, c: 2 },
+  // }
+}
+```
+
 ## APIs Extras
 
 ### Cache Provider

--- a/pages/docs/global-configuration.pt-BR.md
+++ b/pages/docs/global-configuration.pt-BR.md
@@ -37,7 +37,9 @@ function App () {
 
 ## Nesting Configurations
 
-`SWRConfig` merges the configuration from the parent context.
+`SWRConfig` merges the configuration from the parent context. It can receive either an object or a functional configuration. The functional one receives the parent configuration as argument and returns a new configuration that you can customize it yourself. 
+
+### Object Configuration Example
 
 ```jsx
 import { SWRConfig, useSWRConfig } from 'swr'
@@ -53,8 +55,8 @@ function App() {
     >
       <SWRConfig
         value={{
-          dedupingInterval: 200, // override the parent value
-          fallback: { a: 2, c: 2 }, // merge with the parent value
+          dedupingInterval: 200, // will override the parent value since the value is primitive
+          fallback: { a: 2, c: 2 }, // will merge with the parent value since the value is a mergeable object
         }}
       >
         <Page />
@@ -73,7 +75,7 @@ function Page() {
 }
 ```
 
-You can also pass a function as the `value` property when you want to pick some properties from the parent context and decide how to combine them with the current `SWRConfig`. The function receives a parent config and returns a new config.
+### Functional Configuration Example
 
 ```jsx
 import { SWRConfig, useSWRConfig } from 'swr'

--- a/pages/docs/global-configuration.ru.md
+++ b/pages/docs/global-configuration.ru.md
@@ -37,7 +37,9 @@ function App () {
 
 ## Nesting Configurations
 
-`SWRConfig` merges the configuration from the parent context.
+`SWRConfig` merges the configuration from the parent context. It can receive either an object or a functional configuration. The functional one receives the parent configuration as argument and returns a new configuration that you can customize it yourself. 
+
+### Object Configuration Example
 
 ```jsx
 import { SWRConfig, useSWRConfig } from 'swr'
@@ -53,8 +55,8 @@ function App() {
     >
       <SWRConfig
         value={{
-          dedupingInterval: 200, // override the parent value
-          fallback: { a: 2, c: 2 }, // merge with the parent value
+          dedupingInterval: 200, // will override the parent value since the value is primitive
+          fallback: { a: 2, c: 2 }, // will merge with the parent value since the value is a mergeable object
         }}
       >
         <Page />
@@ -73,7 +75,7 @@ function Page() {
 }
 ```
 
-You can also pass a function as the `value` property when you want to pick some properties from the parent context and decide how to combine them with the current `SWRConfig`. The function receives a parent config and returns a new config.
+### Functional Configuration Example
 
 ```jsx
 import { SWRConfig, useSWRConfig } from 'swr'

--- a/pages/docs/global-configuration.ru.md
+++ b/pages/docs/global-configuration.ru.md
@@ -35,6 +35,79 @@ function App () {
 }
 ```
 
+## Nesting Configurations
+
+`SWRConfig` merges the configuration from the parent context.
+
+```jsx
+import { SWRConfig, useSWRConfig } from 'swr'
+
+function App() {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 100,
+        refreshInterval: 100,
+        fallback: { a: 1, b: 1 },
+      }}
+    >
+      <SWRConfig
+        value={{
+          dedupingInterval: 200, // override the parent value
+          fallback: { a: 2, c: 2 }, // merge with the parent value
+        }}
+      >
+        <Page />
+      </SWRConfig>
+    </SWRConfig>
+  )
+}
+
+function Page() {
+  const config = useSWRConfig()
+  // {
+  //   dedupingInterval: 200,
+  //   refreshInterval: 100,
+  //   fallback: { a: 2,  b: 1, c: 2 },
+  // }
+}
+```
+
+You can also pass a function as the `value` property when you want to pick some properties from the parent context and decide how to combine them with the current `SWRConfig`. The function receives a parent config and returns a new config.
+
+```jsx
+import { SWRConfig, useSWRConfig } from 'swr'
+
+function App() {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 100,
+        refreshInterval: 100,
+        fallback: { a: 1, b: 1 },
+      }}
+    >
+      <SWRConfig
+        value={parent => ({
+          dedupingInterval: parent.dedupingInterval * 5,
+          fallback: { a: 2, c: 2 },
+        })}
+      >
+        <Page />
+      </SWRConfig>
+    </SWRConfig>
+  )
+}
+
+function Page() {
+  const config = useSWRConfig()
+  // {
+  //   dedupingInterval: 500,
+  //   fallback: { a: 2, c: 2 },
+  // }
+}
+```
+
 ## Дополнительные API
 
 ### Провайдер кеша

--- a/pages/docs/global-configuration.zh-CN.md
+++ b/pages/docs/global-configuration.zh-CN.md
@@ -37,7 +37,9 @@ function App () {
 
 ## Nesting Configurations
 
-`SWRConfig` merges the configuration from the parent context.
+`SWRConfig` merges the configuration from the parent context. It can receive either an object or a functional configuration. The functional one receives the parent configuration as argument and returns a new configuration that you can customize it yourself. 
+
+### Object Configuration Example
 
 ```jsx
 import { SWRConfig, useSWRConfig } from 'swr'
@@ -53,8 +55,8 @@ function App() {
     >
       <SWRConfig
         value={{
-          dedupingInterval: 200, // override the parent value
-          fallback: { a: 2, c: 2 }, // merge with the parent value
+          dedupingInterval: 200, // will override the parent value since the value is primitive
+          fallback: { a: 2, c: 2 }, // will merge with the parent value since the value is a mergeable object
         }}
       >
         <Page />
@@ -73,7 +75,7 @@ function Page() {
 }
 ```
 
-You can also pass a function as the `value` property when you want to pick some properties from the parent context and decide how to combine them with the current `SWRConfig`. The function receives a parent config and returns a new config.
+### Functional Configuration Example
 
 ```jsx
 import { SWRConfig, useSWRConfig } from 'swr'

--- a/pages/docs/global-configuration.zh-CN.md
+++ b/pages/docs/global-configuration.zh-CN.md
@@ -35,6 +35,79 @@ function App () {
 }
 ```
 
+## Nesting Configurations
+
+`SWRConfig` merges the configuration from the parent context.
+
+```jsx
+import { SWRConfig, useSWRConfig } from 'swr'
+
+function App() {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 100,
+        refreshInterval: 100,
+        fallback: { a: 1, b: 1 },
+      }}
+    >
+      <SWRConfig
+        value={{
+          dedupingInterval: 200, // override the parent value
+          fallback: { a: 2, c: 2 }, // merge with the parent value
+        }}
+      >
+        <Page />
+      </SWRConfig>
+    </SWRConfig>
+  )
+}
+
+function Page() {
+  const config = useSWRConfig()
+  // {
+  //   dedupingInterval: 200,
+  //   refreshInterval: 100,
+  //   fallback: { a: 2,  b: 1, c: 2 },
+  // }
+}
+```
+
+You can also pass a function as the `value` property when you want to pick some properties from the parent context and decide how to combine them with the current `SWRConfig`. The function receives a parent config and returns a new config.
+
+```jsx
+import { SWRConfig, useSWRConfig } from 'swr'
+
+function App() {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 100,
+        refreshInterval: 100,
+        fallback: { a: 1, b: 1 },
+      }}
+    >
+      <SWRConfig
+        value={parent => ({
+          dedupingInterval: parent.dedupingInterval * 5,
+          fallback: { a: 2, c: 2 },
+        })}
+      >
+        <Page />
+      </SWRConfig>
+    </SWRConfig>
+  )
+}
+
+function Page() {
+  const config = useSWRConfig()
+  // {
+  //   dedupingInterval: 500,
+  //   fallback: { a: 2, c: 2 },
+  // }
+}
+```
+
 ## 额外的 API
 
 ### 缓存 Provider


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

This adds documentation for a pattern of nesting configurations with `SWRConfig`, which also includes supporting a function as the SWRConfig value added in v2.
https://github.com/vercel/swr/pull/2024

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


