### PR TITLE
doc: translate typescript page into Japanese

### DIFF
--- a/pages/docs/typescript.ja.mdx
+++ b/pages/docs/typescript.ja.mdx
@@ -34,7 +34,7 @@ const { data } = useSWR(uid, fetcher)
 // `data` は `User | undefined` となります。
 ```
 
-By default, [the error thrown](/docs/error-handling) inside the `fetcher` function has type `any`. The type can also explicitly specified.
+同様に、デフォルトでは、`fetcher`関数内で投げられる[エラー](/docs/error-handling)の型は`any`ですが、型を明示的に指定することができます。
 
 ```typescript
 const { data, error } = useSWR<User, Error>(uid, fetcher);

--- a/pages/docs/typescript.ja.mdx
+++ b/pages/docs/typescript.ja.mdx
@@ -1,10 +1,10 @@
 # TypeScript
 
-SWR は TypeScript で書かされたアプリにも対応、型の安全性をすぐに使えます。
+SWR は TypeScript で書かれたアプリにも対応していて、型の安全性をすぐに使えます。
 
 ## 基本的な使い方
 
-デフォルトでは、SWR は `key` から `fetcher` の引数の型を推測します。そのため、優先される型を自動的に設定できます。
+デフォルトでは、SWR は `key` から `fetcher` の引数の型を推測します。そのため、適切な型を自動的に設定できます。
 
 ### useSWR
 
@@ -38,8 +38,8 @@ const { data } = useSWR(uid, fetcher)
 
 ```typescript
 const { data, error } = useSWR<User, Error>(uid, fetcher);
-// `data` will be `User | undefined`.
-// `error` will be `Error | undefined`.
+// `data` は `User | undefined` となります.
+// `error` は `Error | undefined` となります.
 ```
 
 ### useSWRInfinite

--- a/pages/docs/typescript.ja.mdx
+++ b/pages/docs/typescript.ja.mdx
@@ -34,7 +34,7 @@ const { data } = useSWR(uid, fetcher)
 // `data` は `User | undefined` となります。
 ```
 
-同様に、デフォルトでは、`fetcher`関数内で投げられる[エラー](/docs/error-handling)の型は`any`ですが、型を明示的に指定することができます。
+同様に、デフォルトでは、`fetcher` 関数内で投げられる [エラー](/docs/error-handling) の型は `any` ですが、型を明示的に指定することができます。
 
 ```typescript
 const { data, error } = useSWR<User, Error>(uid, fetcher);


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

I translated into Japanese in TypeScript page which hadn't translated into Japanese or which had seemed to be not properly translated.

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


