### PR TITLE
docs: add an example for preload in effect

### DIFF
--- a/pages/docs/prefetching.en-US.md
+++ b/pages/docs/prefetching.en-US.md
@@ -14,7 +14,9 @@ It will prefetch the data when the HTML loads, even before JavaScript starts to 
 
 ## Programmatically Prefetch
 
-SWR provides the `preload` API to prefetch the resources programmatically and store the results in the cache. `preload` accepts `key` and `fetcher` as the arguments. You can call `preload` even outside of React.
+SWR provides the `preload` API to prefetch the resources programmatically and store the results in the cache. `preload` accepts `key` and `fetcher` as the arguments.
+
+You can call `preload` even outside of React.
 
 ```jsx
 import { useState } from 'react'
@@ -43,38 +45,26 @@ export default function App() {
 }
 ```
 
-You can also preload it when hovering the button:
-
-```jsx
-function App({ userId }) {
-  const [show, setShow] = useState(false)
-  return (
-    <div>
-      <button
-        onClick={() => setShow(true)}
-        onHover={() => preload('/api/user?id=' + userId, fetcher)}
-      >
-        Show User
-      </button>
-      {show ? <User /> : null}
-    </div>
-  )
-}
-```
-
-Within React rendering tree, you can call `preload` in effects.
+Within React rendering tree, event callbacks and effects are also valid places to preload.
 
 ```jsx
 function App({ userId }) {
   const [show, setShow] = useState(false)
 
+  // preload in effects
   useEffect(() => {
     preload('/api/user?id=' + userId, fetcher)
   }, [useId])
 
   return (
     <div>
-      <button onClick={() => setShow(true)}>Show User</button>
+      <button
+        onClick={() => setShow(true)}
+        {/* preload in event callbacks */}
+        onHover={() => preload('/api/user?id=' + userId, fetcher)}
+      >
+        Show User
+      </button>
       {show ? <User /> : null}
     </div>
   )

--- a/pages/docs/prefetching.en-US.md
+++ b/pages/docs/prefetching.en-US.md
@@ -62,7 +62,7 @@ function App({ userId }) {
 }
 ```
 
-Inside React, you can call `preload` in effects.
+Within React rendering tree, you can call `preload` in effects.
 
 ```jsx
 function App({ userId }) {

--- a/pages/docs/prefetching.en-US.md
+++ b/pages/docs/prefetching.en-US.md
@@ -62,6 +62,25 @@ function App({ userId }) {
 }
 ```
 
+Inside React, you can call `preload` in effects.
+
+```jsx
+function App({ userId }) {
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    preload('/api/user?id=' + userId, fetcher)
+  }, [useId])
+
+  return (
+    <div>
+      <button onClick={() => setShow(true)}>Show User</button>
+      {show ? <User /> : null}
+    </div>
+  )
+}
+```
+
 Together with techniques like [page prefetching](https://nextjs.org/docs/api-reference/next/router#routerprefetch) in Next.js, you will be able to load both next page and data instantly.
 
 In Suspense mode, you should utilize `preload` to avoid waterfall problems.

--- a/pages/docs/prefetching.en-US.md
+++ b/pages/docs/prefetching.en-US.md
@@ -45,7 +45,7 @@ export default function App() {
 }
 ```
 
-Within React rendering tree, event callbacks and effects are also valid places to preload.
+Within React rendering tree, `preload` is also avaiable to use in event handlers or effects.
 
 ```jsx
 function App({ userId }) {

--- a/pages/docs/prefetching.es-ES.md
+++ b/pages/docs/prefetching.es-ES.md
@@ -14,7 +14,9 @@ Se precargarán los datos cuando se cargue el HTML, incluso antes de que el Java
 
 ## Programmatically Prefetch
 
-SWR provides the `preload` API to prefetch the resources programmatically and store the results in the cache. `preload` accepts `key` and `fetcher` as the arguments. You can call `preload` even outside of React.
+SWR provides the `preload` API to prefetch the resources programmatically and store the results in the cache. `preload` accepts `key` and `fetcher` as the arguments.
+
+You can call `preload` even outside of React.
 
 ```jsx
 import { useState } from 'react'
@@ -43,38 +45,26 @@ export default function App() {
 }
 ```
 
-You can also preload it when hovering the button:
-
-```jsx
-function App({ userId }) {
-  const [show, setShow] = useState(false)
-  return (
-    <div>
-      <button
-        onClick={() => setShow(true)}
-        onHover={() => preload('/api/user?id=' + userId, fetcher)}
-      >
-        Show User
-      </button>
-      {show ? <User /> : null}
-    </div>
-  )
-}
-```
-
-Inside React, you can call `preload` in effects.
+Within React rendering tree, event callbacks and effects are also valid places to preload.
 
 ```jsx
 function App({ userId }) {
   const [show, setShow] = useState(false)
 
+  // preload in effects
   useEffect(() => {
     preload('/api/user?id=' + userId, fetcher)
   }, [useId])
 
   return (
     <div>
-      <button onClick={() => setShow(true)}>Show User</button>
+      <button
+        onClick={() => setShow(true)}
+        {/* preload in event callbacks */}
+        onHover={() => preload('/api/user?id=' + userId, fetcher)}
+      >
+        Show User
+      </button>
       {show ? <User /> : null}
     </div>
   )

--- a/pages/docs/prefetching.es-ES.md
+++ b/pages/docs/prefetching.es-ES.md
@@ -45,7 +45,7 @@ export default function App() {
 }
 ```
 
-Within React rendering tree, event callbacks and effects are also valid places to preload.
+Within React rendering tree, `preload` is also avaiable to use in event handlers or effects.
 
 ```jsx
 function App({ userId }) {

--- a/pages/docs/prefetching.es-ES.md
+++ b/pages/docs/prefetching.es-ES.md
@@ -62,6 +62,25 @@ function App({ userId }) {
 }
 ```
 
+Inside React, you can call `preload` in effects.
+
+```jsx
+function App({ userId }) {
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    preload('/api/user?id=' + userId, fetcher)
+  }, [useId])
+
+  return (
+    <div>
+      <button onClick={() => setShow(true)}>Show User</button>
+      {show ? <User /> : null}
+    </div>
+  )
+}
+```
+
 Junto con técnicas como [page prefetching](https://nextjs.org/docs/api-reference/next/router#routerprefetch) en Next.js, podrás cargar tanto la siguiente página como los datos al instante.
 
 In Suspense mode, you should utilize `preload` to avoid waterfall problems.

--- a/pages/docs/prefetching.ja.md
+++ b/pages/docs/prefetching.ja.md
@@ -45,7 +45,7 @@ export default function App() {
 }
 ```
 
-React のレンダリングツリー内においては, イベントコールバックやエフェクトはプリロードするために適した場所です。
+React のレンダリングツリー内においては, `preload` はイベントコールバックやエフェクトの中で利用可能です。
 
 ```jsx
 function App({ userId }) {

--- a/pages/docs/prefetching.ja.md
+++ b/pages/docs/prefetching.ja.md
@@ -14,7 +14,9 @@ JavaScriptのダウンロードが開始される前であっても、HTMLの読
 
 ## プログラムによるプリフェッチ
 
-SWR は `preload` というデータをプログラマブルにプリフェッチして結果をキャッシュに保存する API を提供しています。`preload` は `key` と `fetcher` を引数として受け取ります。`preload` は React の外からも呼ぶことが可能です。
+SWR は `preload` というデータをプログラマブルにプリフェッチして結果をキャッシュに保存する API を提供しています。`preload` は `key` と `fetcher` を引数として受け取ります。
+
+`preload` は React の外からも呼ぶことが可能です。
 
 ```jsx
 import { useState } from 'react'
@@ -43,38 +45,26 @@ export default function App() {
 }
 ```
 
-またボタンをホバーしたタイミングでプリロードすることもできます
-
-```jsx
-function App({ userId }) {
-  const [show, setShow] = useState(false)
-  return (
-    <div>
-      <button
-        onClick={() => setShow(true)}
-        onHover={() => preload('/api/user?id=' + userId, fetcher)}
-      >
-        Show User
-      </button>
-      {show ? <User /> : null}
-    </div>
-  )
-}
-```
-
-React の内部においては, `preload` をエフェクトの中から呼ぶことができます。
+React のレンダリングツリー内においては, イベントコールバックやエフェクトはプリロードするために適した場所です。
 
 ```jsx
 function App({ userId }) {
   const [show, setShow] = useState(false)
 
+  // エフェクトの中でプリロードする
   useEffect(() => {
     preload('/api/user?id=' + userId, fetcher)
   }, [useId])
 
   return (
     <div>
-      <button onClick={() => setShow(true)}>Show User</button>
+      <button
+        onClick={() => setShow(true)}
+        {/* イベントコールバックの中でプリロードする */}
+        onHover={() => preload('/api/user?id=' + userId, fetcher)}
+      >
+        Show User
+      </button>
       {show ? <User /> : null}
     </div>
   )

--- a/pages/docs/prefetching.ja.md
+++ b/pages/docs/prefetching.ja.md
@@ -62,6 +62,25 @@ function App({ userId }) {
 }
 ```
 
+React の内部においては, `preload` をエフェクトの中から呼ぶことができます。
+
+```jsx
+function App({ userId }) {
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    preload('/api/user?id=' + userId, fetcher)
+  }, [useId])
+
+  return (
+    <div>
+      <button onClick={() => setShow(true)}>Show User</button>
+      {show ? <User /> : null}
+    </div>
+  )
+}
+```
+
 Next.js の [ページプリフェッチ](https://nextjs.org/docs/api-reference/next/router#routerprefetch) などの技術と合わせて、次のページとデータの両方を瞬時に読み込むことができるようになります。
 
 サスペンスモードでは特に `preload` を利用してウォーターフォール問題を避けた方がいいでしょう。

--- a/pages/docs/prefetching.ko.md
+++ b/pages/docs/prefetching.ko.md
@@ -45,7 +45,7 @@ export default function App() {
 }
 ```
 
-Within React rendering tree, event callbacks and effects are also valid places to preload.
+Within React rendering tree, `preload` is also avaiable to use in event handlers or effects.
 
 ```jsx
 function App({ userId }) {

--- a/pages/docs/prefetching.ko.md
+++ b/pages/docs/prefetching.ko.md
@@ -14,7 +14,9 @@ HTML `<head>` 안에 넣기만 하면 됩니다. 쉽고 빠르며 네이티브�
 
 ## 프로그래밍 방식으로 프리패치
 
-SWR provides the `preload` API to prefetch the resources programmatically and store the results in the cache. `preload` accepts `key` and `fetcher` as the arguments. You can call `preload` even outside of React.
+SWR provides the `preload` API to prefetch the resources programmatically and store the results in the cache. `preload` accepts `key` and `fetcher` as the arguments.
+
+You can call `preload` even outside of React.
 
 ```jsx
 import { useState } from 'react'
@@ -43,38 +45,26 @@ export default function App() {
 }
 ```
 
-You can also preload it when hovering the button:
-
-```jsx
-function App({ userId }) {
-  const [show, setShow] = useState(false)
-  return (
-    <div>
-      <button
-        onClick={() => setShow(true)}
-        onHover={() => preload('/api/user?id=' + userId, fetcher)}
-      >
-        Show User
-      </button>
-      {show ? <User /> : null}
-    </div>
-  )
-}
-```
-
-Inside React, you can call `preload` in effects.
+Within React rendering tree, event callbacks and effects are also valid places to preload.
 
 ```jsx
 function App({ userId }) {
   const [show, setShow] = useState(false)
 
+  // preload in effects
   useEffect(() => {
     preload('/api/user?id=' + userId, fetcher)
   }, [useId])
 
   return (
     <div>
-      <button onClick={() => setShow(true)}>Show User</button>
+      <button
+        onClick={() => setShow(true)}
+        {/* preload in event callbacks */}
+        onHover={() => preload('/api/user?id=' + userId, fetcher)}
+      >
+        Show User
+      </button>
       {show ? <User /> : null}
     </div>
   )

--- a/pages/docs/prefetching.ko.md
+++ b/pages/docs/prefetching.ko.md
@@ -62,6 +62,25 @@ function App({ userId }) {
 }
 ```
 
+Inside React, you can call `preload` in effects.
+
+```jsx
+function App({ userId }) {
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    preload('/api/user?id=' + userId, fetcher)
+  }, [useId])
+
+  return (
+    <div>
+      <button onClick={() => setShow(true)}>Show User</button>
+      {show ? <User /> : null}
+    </div>
+  )
+}
+```
+
 Next.js내의 [페이지 프리패칭](https://nextjs.org/docs/api-reference/next/router#routerprefetch)같은 기술과 함께 다음 페이지와 데이터 모두를 즉시 로드할 수 있습니다.
 
 In Suspense mode, you should utilize `preload` to avoid waterfall problems.

--- a/pages/docs/prefetching.pt-BR.md
+++ b/pages/docs/prefetching.pt-BR.md
@@ -62,6 +62,25 @@ function App({ userId }) {
 }
 ```
 
+Inside React, you can call `preload` in effects.
+
+```jsx
+function App({ userId }) {
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    preload('/api/user?id=' + userId, fetcher)
+  }, [useId])
+
+  return (
+    <div>
+      <button onClick={() => setShow(true)}>Show User</button>
+      {show ? <User /> : null}
+    </div>
+  )
+}
+```
+
 Junto com técnicas como [page prefetching](https://nextjs.org/docs/api-reference/next/router#routerprefetch) no Next.js, você vai ser capaz de carregar ambos a próxima página e os dados instantaneamente.
 
 In Suspense mode, you should utilize `preload` to avoid waterfall problems.

--- a/pages/docs/prefetching.pt-BR.md
+++ b/pages/docs/prefetching.pt-BR.md
@@ -45,7 +45,7 @@ export default function App() {
 }
 ```
 
-Within React rendering tree, event callbacks and effects are also valid places to preload.
+Within React rendering tree, `preload` is also avaiable to use in event handlers or effects.
 
 ```jsx
 function App({ userId }) {

--- a/pages/docs/prefetching.pt-BR.md
+++ b/pages/docs/prefetching.pt-BR.md
@@ -14,7 +14,9 @@ Irá pré-obter os dados quando o HTML carregar, antes mesmo de iniciar a baixar
 
 ## Prefetching Programático
 
-SWR provides the `preload` API to prefetch the resources programmatically and store the results in the cache. `preload` accepts `key` and `fetcher` as the arguments. You can call `preload` even outside of React.
+SWR provides the `preload` API to prefetch the resources programmatically and store the results in the cache. `preload` accepts `key` and `fetcher` as the arguments.
+
+You can call `preload` even outside of React.
 
 ```jsx
 import { useState } from 'react'
@@ -43,38 +45,26 @@ export default function App() {
 }
 ```
 
-You can also preload it when hovering the button:
-
-```jsx
-function App({ userId }) {
-  const [show, setShow] = useState(false)
-  return (
-    <div>
-      <button
-        onClick={() => setShow(true)}
-        onHover={() => preload('/api/user?id=' + userId, fetcher)}
-      >
-        Show User
-      </button>
-      {show ? <User /> : null}
-    </div>
-  )
-}
-```
-
-Inside React, you can call `preload` in effects.
+Within React rendering tree, event callbacks and effects are also valid places to preload.
 
 ```jsx
 function App({ userId }) {
   const [show, setShow] = useState(false)
 
+  // preload in effects
   useEffect(() => {
     preload('/api/user?id=' + userId, fetcher)
   }, [useId])
 
   return (
     <div>
-      <button onClick={() => setShow(true)}>Show User</button>
+      <button
+        onClick={() => setShow(true)}
+        {/* preload in event callbacks */}
+        onHover={() => preload('/api/user?id=' + userId, fetcher)}
+      >
+        Show User
+      </button>
       {show ? <User /> : null}
     </div>
   )

--- a/pages/docs/prefetching.ru.md
+++ b/pages/docs/prefetching.ru.md
@@ -14,7 +14,9 @@
 
 ## Программная предварительная выборка
 
-SWR provides the `preload` API to prefetch the resources programmatically and store the results in the cache. `preload` accepts `key` and `fetcher` as the arguments. You can call `preload` even outside of React.
+SWR provides the `preload` API to prefetch the resources programmatically and store the results in the cache. `preload` accepts `key` and `fetcher` as the arguments.
+
+You can call `preload` even outside of React.
 
 ```jsx
 import { useState } from 'react'
@@ -43,38 +45,26 @@ export default function App() {
 }
 ```
 
-You can also preload it when hovering the button:
-
-```jsx
-function App({ userId }) {
-  const [show, setShow] = useState(false)
-  return (
-    <div>
-      <button
-        onClick={() => setShow(true)}
-        onHover={() => preload('/api/user?id=' + userId, fetcher)}
-      >
-        Show User
-      </button>
-      {show ? <User /> : null}
-    </div>
-  )
-}
-```
-
-Inside React, you can call `preload` in effects.
+Within React rendering tree, event callbacks and effects are also valid places to preload.
 
 ```jsx
 function App({ userId }) {
   const [show, setShow] = useState(false)
 
+  // preload in effects
   useEffect(() => {
     preload('/api/user?id=' + userId, fetcher)
   }, [useId])
 
   return (
     <div>
-      <button onClick={() => setShow(true)}>Show User</button>
+      <button
+        onClick={() => setShow(true)}
+        {/* preload in event callbacks */}
+        onHover={() => preload('/api/user?id=' + userId, fetcher)}
+      >
+        Show User
+      </button>
       {show ? <User /> : null}
     </div>
   )

--- a/pages/docs/prefetching.ru.md
+++ b/pages/docs/prefetching.ru.md
@@ -62,6 +62,25 @@ function App({ userId }) {
 }
 ```
 
+Inside React, you can call `preload` in effects.
+
+```jsx
+function App({ userId }) {
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    preload('/api/user?id=' + userId, fetcher)
+  }, [useId])
+
+  return (
+    <div>
+      <button onClick={() => setShow(true)}>Show User</button>
+      {show ? <User /> : null}
+    </div>
+  )
+}
+```
+
 Вместе с такими техниками, как [предзагрузка страниц](https://nextjs.org/docs/api-reference/next/router#routerprefetch) в Next.js, вы сможете мгновенно загружать как следующую страницу, так и данные.
 
 In Suspense mode, you should utilize `preload` to avoid waterfall problems.

--- a/pages/docs/prefetching.ru.md
+++ b/pages/docs/prefetching.ru.md
@@ -45,7 +45,7 @@ export default function App() {
 }
 ```
 
-Within React rendering tree, event callbacks and effects are also valid places to preload.
+Within React rendering tree, `preload` is also avaiable to use in event handlers or effects.
 
 ```jsx
 function App({ userId }) {

--- a/pages/docs/prefetching.zh-CN.md
+++ b/pages/docs/prefetching.zh-CN.md
@@ -62,6 +62,25 @@ function App({ userId }) {
 }
 ```
 
+Inside React, you can call `preload` in effects.
+
+```jsx
+function App({ userId }) {
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    preload('/api/user?id=' + userId, fetcher)
+  }, [useId])
+
+  return (
+    <div>
+      <button onClick={() => setShow(true)}>Show User</button>
+      {show ? <User /> : null}
+    </div>
+  )
+}
+```
+
 配合 Next.js 的 [页面预加载](https://nextjs.org/docs/api-reference/next/router#routerprefetch)，你将能立即加载下一页和数据。
 
 In Suspense mode, you should utilize `preload` to avoid waterfall problems.

--- a/pages/docs/prefetching.zh-CN.md
+++ b/pages/docs/prefetching.zh-CN.md
@@ -45,7 +45,7 @@ export default function App() {
 }
 ```
 
-Within React rendering tree, event callbacks and effects are also valid places to preload.
+Within React rendering tree, `preload` is also avaiable to use in event handlers or effects.
 
 ```jsx
 function App({ userId }) {

--- a/pages/docs/prefetching.zh-CN.md
+++ b/pages/docs/prefetching.zh-CN.md
@@ -14,7 +14,9 @@
 
 ## 手动预请求
 
-SWR provides the `preload` API to prefetch the resources programmatically and store the results in the cache. `preload` accepts `key` and `fetcher` as the arguments. You can call `preload` even outside of React.
+SWR provides the `preload` API to prefetch the resources programmatically and store the results in the cache. `preload` accepts `key` and `fetcher` as the arguments.
+
+You can call `preload` even outside of React.
 
 ```jsx
 import { useState } from 'react'
@@ -43,38 +45,26 @@ export default function App() {
 }
 ```
 
-You can also preload it when hovering the button:
-
-```jsx
-function App({ userId }) {
-  const [show, setShow] = useState(false)
-  return (
-    <div>
-      <button
-        onClick={() => setShow(true)}
-        onHover={() => preload('/api/user?id=' + userId, fetcher)}
-      >
-        Show User
-      </button>
-      {show ? <User /> : null}
-    </div>
-  )
-}
-```
-
-Inside React, you can call `preload` in effects.
+Within React rendering tree, event callbacks and effects are also valid places to preload.
 
 ```jsx
 function App({ userId }) {
   const [show, setShow] = useState(false)
 
+  // preload in effects
   useEffect(() => {
     preload('/api/user?id=' + userId, fetcher)
   }, [useId])
 
   return (
     <div>
-      <button onClick={() => setShow(true)}>Show User</button>
+      <button
+        onClick={() => setShow(true)}
+        {/* preload in event callbacks */}
+        onHover={() => preload('/api/user?id=' + userId, fetcher)}
+      >
+        Show User
+      </button>
       {show ? <User /> : null}
     </div>
   )


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

<!-- What're you changing? -->

This adds an example  for the `preload` API in effects, which @huozhi mentioned in https://github.com/vercel/swr-site/pull/336#discussion_r958432267.

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


