### PR TITLE
sync and refine mutate page

### DIFF
--- a/pages/docs/mutation.en-US.md
+++ b/pages/docs/mutation.en-US.md
@@ -5,7 +5,7 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-mutate(key, data, options)
+const data = await mutate(key, data, options)
 ```
 
 ### API
@@ -19,6 +19,18 @@ mutate(key, data, options)
   - `revalidate = true`: should the cache revalidate once the asynchronous update resolves.
   - `populateCache = true`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
   - `rollbackOnError = true`: should the cache rollback if the remote mutation errors.
+
+#### Return Values
+
+`mutate` returns the results the `data` parameter has been resolved. The function passed to `mutate` will return an updated data which is used to update the corresponding cache value. If there is an error thrown while executing the function, the error will be thrown so it can be handled appropriately.
+
+```jsx
+try {
+  const user = await mutate('/api/user', updateUser(newUser))
+} catch (error) {
+  // Handle an error while updating the user here
+}
+```
 
 ## Revalidate
 
@@ -153,20 +165,6 @@ mutate('/api/todos', updateTodo, {
   // we don't need to revalidate here.
   revalidate: false
 })
-```
-
-## Returned Data from Mutate
-
-Most probably, you need some data to update the cache. The data is resolved or returned from the promise or async function you passed to `mutate`.
-
-The function passed to `mutate` will return an updated document which is used to update the corresponding cache value. If there is an error thrown while executing the function, the error will be thrown so it can be handled appropriately.
-
-```jsx
-try {
-  const user = await mutate('/api/user', updateUser(newUser))
-} catch (error) {
-  // Handle an error while updating the user here
-}
 ```
 
 ## Mutate Multiple Items

--- a/pages/docs/mutation.es-ES.md
+++ b/pages/docs/mutation.es-ES.md
@@ -5,7 +5,7 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-mutate(key, data, options)
+const data = await mutate(key, data, options)
 ```
 
 ### API
@@ -19,6 +19,18 @@ mutate(key, data, options)
   - `revalidate = true`: should the cache revalidate once the asynchronous update resolves.
   - `populateCache = true`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
   - `rollbackOnError = true`: should the cache rollback if the remote mutation errors.
+
+#### Return Values
+
+`mutate` returns the results the `data` parameter has been resolved. The function passed to `mutate` will return an updated data which is used to update the corresponding cache value. If there is an error thrown while executing the function, the error will be thrown so it can be handled appropriately.
+
+```jsx
+try {
+  const user = await mutate('/api/user', updateUser(newUser))
+} catch (error) {
+  // Manejar un error al actualizar el user aquí
+}
+```
 
 ## Revalidar
 
@@ -151,21 +163,6 @@ mutate('/api/todos', updateTodo, {
   // we don't need to revalidate here.
   revalidate: false
 })
-```
-
-## Datos devueltos por Mutate
-
-Lo más probable es que necesites algunos datos para actualizar la caché. Los datos se resuelven o se devuelven
-desde la promise o función asíncrona que pasaste para `mutate`.
-
-La función devolverá update document para que `mutate` actualice el valor de la caché correspondiente. Podría arrojar un error de alguna manera, cada vez que se llame.
-
-```jsx
-try {
-  const user = await mutate('/api/user', updateUser(newUser))
-} catch (error) {
-  // Manejar un error al actualizar el user aquí
-}
 ```
 
 ## Mutate Multiple Items

--- a/pages/docs/mutation.es-ES.md
+++ b/pages/docs/mutation.es-ES.md
@@ -1,15 +1,24 @@
 # Mutación
 
+SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and related cache.
+
+## mutate
+
 ```js
 mutate(key, data, options)
 ```
 
-## Options
+### API
 
-- `optimisticData`: data to immediately update the client cache, or a function that receives current data and returns the new client cache data, usually used in optimistic UI.
-- `revalidate`: should the cache revalidate once the asynchronous update resolves.
-- `populateCache`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
-- `rollbackOnError`: should the cache rollback if the remote mutation errors.
+#### Parameters
+
+- `key`: same as `useSWR`'s `key`
+- `data`: data to update the client cache, or an async function for the remote mutation
+- `options`: accepts the following options
+  - `optimisticData(currentData)`: data to immediately update the client cache, or a function that receives current data and returns the new client cache data, usually used in optimistic UI.
+  - `revalidate = true`: should the cache revalidate once the asynchronous update resolves.
+  - `populateCache = true`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
+  - `rollbackOnError = true`: should the cache rollback if the remote mutation errors.
 
 ## Revalidar
 
@@ -235,5 +244,123 @@ function Profile () {
       }}>Uppercase my name!</button>
     </div>
   )
+}
+```
+
+## useSWRMutation
+
+SWR also provides `useSWRMutation` as a hook for remote mutations. The remote mutations are only triggered manually, instead of automatically like `useSWR`.
+
+```jsx
+import useSWRMutation from 'swr/mutation'
+
+async function getData(url, { arg }) {
+  // Fetcher implementation.
+  // The extra argument will be passed via the `arg` property of the 2nd parameter.
+  // For the example below, `arg` will be `'my_token'`
+}
+
+// A useSWR + mutate like API, but it will never start the request.
+const { data, error, trigger, reset, isMutating } = useSWRMutation('/api/user', getData, options?)
+trigger('my_token');
+```
+
+### API
+
+#### Parameters
+
+- `key`:  same as `useSWR`'s `key`
+- `fetcher(key, { arg })`: an async function for remote mutation
+- `options`: accepts the following options
+  - `optimisticData(currentData)`: same as `mutate`'s `optimisticData`
+  - `revalidate = true`: same as `mutate`'s `revalidate`
+  - `populateCache = false`: same as `mutate`'s `populateCache`, but the default is `false`
+  - `rollbackOnError = true`: same as `mutate`'s `rollbackOnError`
+  - `onSuccess(data, key, config)`:　callback function when a remote mutation has been finished successfully
+  - `onError(err, key, config)`: callback function when a remote mutation has returned an error
+
+#### Return Values
+
+- `data`: data for the given key returned from `fetcher`
+- `error`: error thrown by `fetcher` (or undefined)
+- `trigger(arg, options)`: a function to trigger a remote mutation
+- `reset`: a function to reset the state (`data`, `error`, `isMutating`)
+- `isMutating`: if there's an ongoing remote mutation
+
+### Basic Examples
+
+```jsx
+import useSWRMutation from 'swr/mutation'
+
+async function sendRequest(url, { arg }) {
+  return fetch(url, {
+    method: 'POST',
+    body: JSON.stringify(arg)
+  })
+}
+
+function App() {
+  const { trigger } = useSWRMutation('/api/user', sendRequest, /* options */)
+
+  return (
+    <button
+      onClick={async () => {
+        try {
+          const result = await trigger({ username: 'johndoe' }, /* options */)
+        } catch (e) {
+          // error handling
+        }
+      }}
+    >
+      Create User
+    </button>
+  )
+}
+```
+
+If you want to use the mutation results in rendering, you can get them from the return values of `useSWRMutation`.
+
+```jsx
+const { trigger, data, error } = useSWRMutation('/api/user', sendRequest)
+```
+
+`useSWRMutation` shares a cache store with `useSWR`, so it can detect and avoid race conditions between `useSWR`. It also supports `mutate`'s functionalities like optimistic updates and rollback on errors. You can pass these options `useSWRMutation` and its `trigger` function.
+
+```jsx
+const { trigger } = useSWRMutation('/api/user', updateUser, {
+  optimisticData: current => ({ ...current, name: newName })
+})
+
+// or
+
+trigger(newName, {
+  optimisticData: current => ({ ...current, name: newName })
+})
+```
+
+### Defer loading data until needed
+
+You can also use `useSWRMutation` for loading data. `useSWRMutation` never start requesting until `trigger` is called, so you can defer loading data when you actually need it.
+
+```jsx
+import { useState } from 'react'
+import useSWRMutation from 'swr/mutation'
+
+const fetcher = url => fetch(url).then(res => res.json())
+
+const Page = () => {
+  const [show, setShow] = useState(false)
+  // data is undefined until trigger is called
+  const { data: user, trigger } = useSWR('/api/user', fetcher);
+
+  return (
+    <div>
+      <button onClick={() => {
+        trigger();
+        setShow(true);
+      }}>Show User</button>
+      {show && user ? <div>{usre.name}</div> : null}
+    </div>
+  );
 }
 ```

--- a/pages/docs/mutation.ja.md
+++ b/pages/docs/mutation.ja.md
@@ -5,7 +5,7 @@ SWR はリモートデータ及びキャッシュデータの更新のために 
 ## mutate
 
 ```js
-mutate(key, data, options)
+const data = await mutate(key, data, options)
 ```
 
 ### API
@@ -19,6 +19,19 @@ mutate(key, data, options)
   - `revalidate = true`: リモートミューテーションが完了した際にキャッシュを再検証するかどうか
   - `populateCache = true`: リモートミューテーションの結果をキャッシュに書き込むかどうか、または更新後のデータと現在のデータを受け取りミューテーションの結果としてキャッシュに保存するデータを返す関数
   - `rollbackOnError = true`: リモートミューテーションでエラーが発生した才にキャッシュをロールバックするかどうか
+
+#### 返り値
+
+`mutate` は `data` パラメーターが解決された結果を返します。`mutate` に渡されるこの関数は、対応するキャッシュ値を更新できるように、更新されたデータを返します。この関数を実行している際にエラーが発生したときには、適切な対処ができるようにそのエラーを投げます。
+
+
+```jsx
+try {
+  const user = await mutate('/api/user', updateUser(newUser))
+} catch (error) {
+  // ここでユーザーの更新中にエラーを処理します
+}
+```
 
 ## 再検証
 
@@ -153,20 +166,6 @@ mutate('/api/todos', updateTodo, {
   // 再検証する必要はありません
   revalidate: false
 })
-```
-
-## ミューテートから返されたデータ
-
-ほとんどの場合、キャッシュを更新するためにいくつかのデータが必要です。データは、`mutate` に渡された promise や非同期関数から解決または返されます。
-
-`mutate` に渡されるこの関数は、対応するキャッシュ値を更新できるように、更新されたドキュメントを返します。この関数を実行している際にエラーが発生したときには、適切な対処ができるようにそのエラーを投げます。
-
-```jsx
-try {
-  const user = await mutate('/api/user', updateUser(newUser))
-} catch (error) {
-  // ここでユーザーの更新中にエラーを処理します
-}
 ```
 
 ## 複数のアイテムをミューテートする

--- a/pages/docs/mutation.ko.md
+++ b/pages/docs/mutation.ko.md
@@ -1,15 +1,24 @@
 # 뮤테이션
 
+SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and related cache.
+
+## mutate
+
 ```js
 mutate(key, data, options)
 ```
 
-## Options
+### API
 
-- `optimisticData`: data to immediately update the client cache, or a function that receives current data and returns the new client cache data, usually used in optimistic UI.
-- `revalidate`: 비동기 업데이트가 해소되면 캐시를 갱신합니다.
-- `populateCache`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
-- `rollbackOnError`: 원격 뮤테이션 에러 시 캐시를 롤백합니다.
+#### Parameters
+
+- `key`: same as `useSWR`'s `key`
+- `data`: data to update the client cache, or an async function for the remote mutation
+- `options`: accepts the following options
+  - `optimisticData(currentData)`: data to immediately update the client cache, or a function that receives current data and returns the new client cache data, usually used in optimistic UI.
+  - `revalidate = true`: should the cache revalidate once the asynchronous update resolves.
+  - `populateCache = true`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
+  - `rollbackOnError = true`: should the cache rollback if the remote mutation errors.
 
 ## 갱신하기
 
@@ -236,5 +245,123 @@ function Profile () {
       }}>Uppercase my name!</button>
     </div>
   )
+}
+```
+
+## useSWRMutation
+
+SWR also provides `useSWRMutation` as a hook for remote mutations. The remote mutations are only triggered manually, instead of automatically like `useSWR`.
+
+```jsx
+import useSWRMutation from 'swr/mutation'
+
+async function getData(url, { arg }) {
+  // Fetcher implementation.
+  // The extra argument will be passed via the `arg` property of the 2nd parameter.
+  // For the example below, `arg` will be `'my_token'`
+}
+
+// A useSWR + mutate like API, but it will never start the request.
+const { data, error, trigger, reset, isMutating } = useSWRMutation('/api/user', getData, options?)
+trigger('my_token');
+```
+
+### API
+
+#### Parameters
+
+- `key`:  same as `useSWR`'s `key`
+- `fetcher(key, { arg })`: an async function for remote mutation
+- `options`: accepts the following options
+  - `optimisticData(currentData)`: same as `mutate`'s `optimisticData`
+  - `revalidate = true`: same as `mutate`'s `revalidate`
+  - `populateCache = false`: same as `mutate`'s `populateCache`, but the default is `false`
+  - `rollbackOnError = true`: same as `mutate`'s `rollbackOnError`
+  - `onSuccess(data, key, config)`:　callback function when a remote mutation has been finished successfully
+  - `onError(err, key, config)`: callback function when a remote mutation has returned an error
+
+#### Return Values
+
+- `data`: data for the given key returned from `fetcher`
+- `error`: error thrown by `fetcher` (or undefined)
+- `trigger(arg, options)`: a function to trigger a remote mutation
+- `reset`: a function to reset the state (`data`, `error`, `isMutating`)
+- `isMutating`: if there's an ongoing remote mutation
+
+### Basic Examples
+
+```jsx
+import useSWRMutation from 'swr/mutation'
+
+async function sendRequest(url, { arg }) {
+  return fetch(url, {
+    method: 'POST',
+    body: JSON.stringify(arg)
+  })
+}
+
+function App() {
+  const { trigger } = useSWRMutation('/api/user', sendRequest, /* options */)
+
+  return (
+    <button
+      onClick={async () => {
+        try {
+          const result = await trigger({ username: 'johndoe' }, /* options */)
+        } catch (e) {
+          // error handling
+        }
+      }}
+    >
+      Create User
+    </button>
+  )
+}
+```
+
+If you want to use the mutation results in rendering, you can get them from the return values of `useSWRMutation`.
+
+```jsx
+const { trigger, data, error } = useSWRMutation('/api/user', sendRequest)
+```
+
+`useSWRMutation` shares a cache store with `useSWR`, so it can detect and avoid race conditions between `useSWR`. It also supports `mutate`'s functionalities like optimistic updates and rollback on errors. You can pass these options `useSWRMutation` and its `trigger` function.
+
+```jsx
+const { trigger } = useSWRMutation('/api/user', updateUser, {
+  optimisticData: current => ({ ...current, name: newName })
+})
+
+// or
+
+trigger(newName, {
+  optimisticData: current => ({ ...current, name: newName })
+})
+```
+
+### Defer loading data until needed
+
+You can also use `useSWRMutation` for loading data. `useSWRMutation` never start requesting until `trigger` is called, so you can defer loading data when you actually need it.
+
+```jsx
+import { useState } from 'react'
+import useSWRMutation from 'swr/mutation'
+
+const fetcher = url => fetch(url).then(res => res.json())
+
+const Page = () => {
+  const [show, setShow] = useState(false)
+  // data is undefined until trigger is called
+  const { data: user, trigger } = useSWR('/api/user', fetcher);
+
+  return (
+    <div>
+      <button onClick={() => {
+        trigger();
+        setShow(true);
+      }}>Show User</button>
+      {show && user ? <div>{usre.name}</div> : null}
+    </div>
+  );
 }
 ```

--- a/pages/docs/mutation.ko.md
+++ b/pages/docs/mutation.ko.md
@@ -5,7 +5,7 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-mutate(key, data, options)
+const data = await mutate(key, data, options)
 ```
 
 ### API
@@ -19,6 +19,18 @@ mutate(key, data, options)
   - `revalidate = true`: should the cache revalidate once the asynchronous update resolves.
   - `populateCache = true`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
   - `rollbackOnError = true`: should the cache rollback if the remote mutation errors.
+
+#### Return Values
+
+`mutate` returns the results the `data` parameter has been resolved. The function passed to `mutate` will return an updated data which is used to update the corresponding cache value. If there is an error thrown while executing the function, the error will be thrown so it can be handled appropriately.
+
+```jsx
+try {
+  const user = await mutate('/api/user', updateUser(newUser))
+} catch (error) {
+  // 여기에서 user를 업데이트하는 동안 발생하는 에러를 처리
+}
+```
 
 ## 갱신하기
 
@@ -153,21 +165,6 @@ mutate('/api/todos', updateTodo, {
   // we don't need to revalidate here.
   revalidate: false
 })
-```
-
-## 뮤테이트로부터 반환된 데이터
-
-여러분 대부분은 아마도 캐시를 업데이트하기 위한 어떤 데이터가 필요할 것입니다. 데이터는 `mutate`로 전달했던 프로미스나 비동기 함수로부터 이행되었거나 반환되었습니다.
-
-`mutate`로 전달된 함수는 적합한 캐시 값을 업데이트하기 위해 사용되는 업데이트된 문서를 반환합니다. 해당 함수를 실행하는 동안 에러가 발생한다면,
-적절하게 처리할 수 있도록 에러가 던져집니다.
-
-```jsx
-try {
-  const user = await mutate('/api/user', updateUser(newUser))
-} catch (error) {
-  // 여기에서 user를 업데이트하는 동안 발생하는 에러를 처리
-}
 ```
 
 ## Mutate Multiple Items

--- a/pages/docs/mutation.pt-BR.md
+++ b/pages/docs/mutation.pt-BR.md
@@ -5,7 +5,7 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-mutate(key, data, options)
+const data = await mutate(key, data, options)
 ```
 
 ### API
@@ -19,6 +19,18 @@ mutate(key, data, options)
   - `revalidate = true`: should the cache revalidate once the asynchronous update resolves.
   - `populateCache = true`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
   - `rollbackOnError = true`: should the cache rollback if the remote mutation errors.
+
+#### Return Values
+
+`mutate` returns the results the `data` parameter has been resolved. The function passed to `mutate` will return an updated data which is used to update the corresponding cache value. If there is an error thrown while executing the function, the error will be thrown so it can be handled appropriately.
+
+```jsx
+try {
+  const user = await mutate('/api/user', updateUser(newUser))
+} catch (error) {
+  // Lide com um erro enquanto atualiza o usuário aqui
+}
+```
 
 ## Revalidar
 
@@ -152,20 +164,6 @@ mutate('/api/todos', updateTodo, {
   // we don't need to revalidate here.
   revalidate: false
 })
-```
-
-## Data Retornada da Mutação
-
-Mais provavelmente, você precisa de algum dado para atualizar o cache. O dado é resolvido ou retornado da função ou função assíncrona que você passou para `mutate`.
-
-A função passada para `mutate` retornará um documento atualizado que é usado para atualizar o valor correspondente no cache. Se houver um erro ao executar a função, o erro será lançado para que possa ser tratado adequadamente.
-
-```jsx
-try {
-  const user = await mutate('/api/user', updateUser(newUser))
-} catch (error) {
-  // Lide com um erro enquanto atualiza o usuário aqui
-}
 ```
 
 ## Mutate Multiple Items

--- a/pages/docs/mutation.pt-BR.md
+++ b/pages/docs/mutation.pt-BR.md
@@ -1,15 +1,24 @@
 # Mutação
 
+SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and related cache.
+
+## mutate
+
 ```js
 mutate(key, data, options)
 ```
 
-## Opções
+### API
 
-- `optimisticData`: data to immediately update the client cache, or a function that receives current data and returns the new client cache data, usually used in optimistic UI.
-- `revalidate`: se o cache deve revalidar quando a atualização assíncrona resolve.
-- `populateCache`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
-- `rollbackOnError`: se o cache deve reverter se a mutação remota falhar.
+#### Parameters
+
+- `key`: same as `useSWR`'s `key`
+- `data`: data to update the client cache, or an async function for the remote mutation
+- `options`: accepts the following options
+  - `optimisticData(currentData)`: data to immediately update the client cache, or a function that receives current data and returns the new client cache data, usually used in optimistic UI.
+  - `revalidate = true`: should the cache revalidate once the asynchronous update resolves.
+  - `populateCache = true`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
+  - `rollbackOnError = true`: should the cache rollback if the remote mutation errors.
 
 ## Revalidar
 
@@ -235,5 +244,123 @@ function Profile () {
       }}>Uppercase my name!</button>
     </div>
   )
+}
+```
+
+## useSWRMutation
+
+SWR also provides `useSWRMutation` as a hook for remote mutations. The remote mutations are only triggered manually, instead of automatically like `useSWR`.
+
+```jsx
+import useSWRMutation from 'swr/mutation'
+
+async function getData(url, { arg }) {
+  // Fetcher implementation.
+  // The extra argument will be passed via the `arg` property of the 2nd parameter.
+  // For the example below, `arg` will be `'my_token'`
+}
+
+// A useSWR + mutate like API, but it will never start the request.
+const { data, error, trigger, reset, isMutating } = useSWRMutation('/api/user', getData, options?)
+trigger('my_token');
+```
+
+### API
+
+#### Parameters
+
+- `key`:  same as `useSWR`'s `key`
+- `fetcher(key, { arg })`: an async function for remote mutation
+- `options`: accepts the following options
+  - `optimisticData(currentData)`: same as `mutate`'s `optimisticData`
+  - `revalidate = true`: same as `mutate`'s `revalidate`
+  - `populateCache = false`: same as `mutate`'s `populateCache`, but the default is `false`
+  - `rollbackOnError = true`: same as `mutate`'s `rollbackOnError`
+  - `onSuccess(data, key, config)`:　callback function when a remote mutation has been finished successfully
+  - `onError(err, key, config)`: callback function when a remote mutation has returned an error
+
+#### Return Values
+
+- `data`: data for the given key returned from `fetcher`
+- `error`: error thrown by `fetcher` (or undefined)
+- `trigger(arg, options)`: a function to trigger a remote mutation
+- `reset`: a function to reset the state (`data`, `error`, `isMutating`)
+- `isMutating`: if there's an ongoing remote mutation
+
+### Basic Examples
+
+```jsx
+import useSWRMutation from 'swr/mutation'
+
+async function sendRequest(url, { arg }) {
+  return fetch(url, {
+    method: 'POST',
+    body: JSON.stringify(arg)
+  })
+}
+
+function App() {
+  const { trigger } = useSWRMutation('/api/user', sendRequest, /* options */)
+
+  return (
+    <button
+      onClick={async () => {
+        try {
+          const result = await trigger({ username: 'johndoe' }, /* options */)
+        } catch (e) {
+          // error handling
+        }
+      }}
+    >
+      Create User
+    </button>
+  )
+}
+```
+
+If you want to use the mutation results in rendering, you can get them from the return values of `useSWRMutation`.
+
+```jsx
+const { trigger, data, error } = useSWRMutation('/api/user', sendRequest)
+```
+
+`useSWRMutation` shares a cache store with `useSWR`, so it can detect and avoid race conditions between `useSWR`. It also supports `mutate`'s functionalities like optimistic updates and rollback on errors. You can pass these options `useSWRMutation` and its `trigger` function.
+
+```jsx
+const { trigger } = useSWRMutation('/api/user', updateUser, {
+  optimisticData: current => ({ ...current, name: newName })
+})
+
+// or
+
+trigger(newName, {
+  optimisticData: current => ({ ...current, name: newName })
+})
+```
+
+### Defer loading data until needed
+
+You can also use `useSWRMutation` for loading data. `useSWRMutation` never start requesting until `trigger` is called, so you can defer loading data when you actually need it.
+
+```jsx
+import { useState } from 'react'
+import useSWRMutation from 'swr/mutation'
+
+const fetcher = url => fetch(url).then(res => res.json())
+
+const Page = () => {
+  const [show, setShow] = useState(false)
+  // data is undefined until trigger is called
+  const { data: user, trigger } = useSWR('/api/user', fetcher);
+
+  return (
+    <div>
+      <button onClick={() => {
+        trigger();
+        setShow(true);
+      }}>Show User</button>
+      {show && user ? <div>{usre.name}</div> : null}
+    </div>
+  );
 }
 ```

--- a/pages/docs/mutation.ru.md
+++ b/pages/docs/mutation.ru.md
@@ -5,7 +5,7 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-mutate(key, data, options)
+const data = await mutate(key, data, options)
 ```
 
 ### API
@@ -19,6 +19,18 @@ mutate(key, data, options)
   - `revalidate = true`: should the cache revalidate once the asynchronous update resolves.
   - `populateCache = true`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
   - `rollbackOnError = true`: should the cache rollback if the remote mutation errors.
+
+#### Return Values
+
+`mutate` returns the results the `data` parameter has been resolved. The function passed to `mutate` will return an updated data which is used to update the corresponding cache value. If there is an error thrown while executing the function, the error will be thrown so it can be handled appropriately.
+
+```jsx
+try {
+  const user = await mutate('/api/user', updateUser(newUser))
+} catch (error) {
+  // Обработайте ошибку здесь при обновлении пользователя
+}
+```
 
 ## Ревалидация
 
@@ -149,20 +161,6 @@ mutate('/api/todos', updateTodo, {
   // we don't need to revalidate here.
   revalidate: false
 })
-```
-
-## Возвращенные данные из мутации
-
-Скорее всего, вам понадобятся данные для обновления кеша. Данные разрешаются или возвращаются из промиса или асинхронной функции, переданной в `mutate`.
-
-Функция, переданная в `mutate`, вернёт обновлённый документ, который используется для обновления соответствующего значения кеша. Если при выполнении функции выбрасывается ошибка, она будет выведена, чтобы её можно было обработать должным образом.
-
-```jsx
-try {
-  const user = await mutate('/api/user', updateUser(newUser))
-} catch (error) {
-  // Обработайте ошибку здесь при обновлении пользователя
-}
 ```
 
 ## Mutate Multiple Items

--- a/pages/docs/mutation.ru.md
+++ b/pages/docs/mutation.ru.md
@@ -1,15 +1,24 @@
 # Мутация
 
+SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and related cache.
+
+## mutate
+
 ```js
 mutate(key, data, options)
 ```
 
-## Опции
+### API
 
-- `optimisticData`: data to immediately update the client cache, or a function that receives current data and returns the new client cache data, usually used in optimistic UI.
-- `revalidate`: должен ли кеш повторно проверяться после разрешения асинхронного обновления.
-- `populateCache`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
-- `rollbackOnError`: следует ли выполнять откат кеша в случае ошибок удаленной мутации.
+#### Parameters
+
+- `key`: same as `useSWR`'s `key`
+- `data`: data to update the client cache, or an async function for the remote mutation
+- `options`: accepts the following options
+  - `optimisticData(currentData)`: data to immediately update the client cache, or a function that receives current data and returns the new client cache data, usually used in optimistic UI.
+  - `revalidate = true`: should the cache revalidate once the asynchronous update resolves.
+  - `populateCache = true`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
+  - `rollbackOnError = true`: should the cache rollback if the remote mutation errors.
 
 ## Ревалидация
 
@@ -232,5 +241,123 @@ function Profile () {
       }}>Перевести моё имя в верхний регистр!</button>
     </div>
   )
+}
+```
+
+## useSWRMutation
+
+SWR also provides `useSWRMutation` as a hook for remote mutations. The remote mutations are only triggered manually, instead of automatically like `useSWR`.
+
+```jsx
+import useSWRMutation from 'swr/mutation'
+
+async function getData(url, { arg }) {
+  // Fetcher implementation.
+  // The extra argument will be passed via the `arg` property of the 2nd parameter.
+  // For the example below, `arg` will be `'my_token'`
+}
+
+// A useSWR + mutate like API, but it will never start the request.
+const { data, error, trigger, reset, isMutating } = useSWRMutation('/api/user', getData, options?)
+trigger('my_token');
+```
+
+### API
+
+#### Parameters
+
+- `key`:  same as `useSWR`'s `key`
+- `fetcher(key, { arg })`: an async function for remote mutation
+- `options`: accepts the following options
+  - `optimisticData(currentData)`: same as `mutate`'s `optimisticData`
+  - `revalidate = true`: same as `mutate`'s `revalidate`
+  - `populateCache = false`: same as `mutate`'s `populateCache`, but the default is `false`
+  - `rollbackOnError = true`: same as `mutate`'s `rollbackOnError`
+  - `onSuccess(data, key, config)`:　callback function when a remote mutation has been finished successfully
+  - `onError(err, key, config)`: callback function when a remote mutation has returned an error
+
+#### Return Values
+
+- `data`: data for the given key returned from `fetcher`
+- `error`: error thrown by `fetcher` (or undefined)
+- `trigger(arg, options)`: a function to trigger a remote mutation
+- `reset`: a function to reset the state (`data`, `error`, `isMutating`)
+- `isMutating`: if there's an ongoing remote mutation
+
+### Basic Examples
+
+```jsx
+import useSWRMutation from 'swr/mutation'
+
+async function sendRequest(url, { arg }) {
+  return fetch(url, {
+    method: 'POST',
+    body: JSON.stringify(arg)
+  })
+}
+
+function App() {
+  const { trigger } = useSWRMutation('/api/user', sendRequest, /* options */)
+
+  return (
+    <button
+      onClick={async () => {
+        try {
+          const result = await trigger({ username: 'johndoe' }, /* options */)
+        } catch (e) {
+          // error handling
+        }
+      }}
+    >
+      Create User
+    </button>
+  )
+}
+```
+
+If you want to use the mutation results in rendering, you can get them from the return values of `useSWRMutation`.
+
+```jsx
+const { trigger, data, error } = useSWRMutation('/api/user', sendRequest)
+```
+
+`useSWRMutation` shares a cache store with `useSWR`, so it can detect and avoid race conditions between `useSWR`. It also supports `mutate`'s functionalities like optimistic updates and rollback on errors. You can pass these options `useSWRMutation` and its `trigger` function.
+
+```jsx
+const { trigger } = useSWRMutation('/api/user', updateUser, {
+  optimisticData: current => ({ ...current, name: newName })
+})
+
+// or
+
+trigger(newName, {
+  optimisticData: current => ({ ...current, name: newName })
+})
+```
+
+### Defer loading data until needed
+
+You can also use `useSWRMutation` for loading data. `useSWRMutation` never start requesting until `trigger` is called, so you can defer loading data when you actually need it.
+
+```jsx
+import { useState } from 'react'
+import useSWRMutation from 'swr/mutation'
+
+const fetcher = url => fetch(url).then(res => res.json())
+
+const Page = () => {
+  const [show, setShow] = useState(false)
+  // data is undefined until trigger is called
+  const { data: user, trigger } = useSWR('/api/user', fetcher);
+
+  return (
+    <div>
+      <button onClick={() => {
+        trigger();
+        setShow(true);
+      }}>Show User</button>
+      {show && user ? <div>{usre.name}</div> : null}
+    </div>
+  );
 }
 ```

--- a/pages/docs/mutation.zh-CN.md
+++ b/pages/docs/mutation.zh-CN.md
@@ -5,7 +5,7 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-mutate(key, data, options)
+const data = await mutate(key, data, options)
 ```
 
 ### API
@@ -19,6 +19,18 @@ mutate(key, data, options)
   - `revalidate = true`: should the cache revalidate once the asynchronous update resolves.
   - `populateCache = true`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
   - `rollbackOnError = true`: should the cache rollback if the remote mutation errors.
+
+#### Return Values
+
+`mutate` returns the results the `data` parameter has been resolved. The function passed to `mutate` will return an updated data which is used to update the corresponding cache value. If there is an error thrown while executing the function, the error will be thrown so it can be handled appropriately.
+
+```jsx
+try {
+  const user = await mutate('/api/user', updateUser(newUser))
+} catch (error) {
+  // 在这里处理更新 user 时的错误
+}
+```
 
 ## 重新验证
 
@@ -148,20 +160,6 @@ mutate('/api/todos', updateTodo, {
   // we don't need to revalidate here.
   revalidate: false
 })
-```
-
-## Mutate 的返回值
-
-最有可能的是，你需要一些数据来更新缓存。这些数据是从你传递给 `mutate` 的 promise 或 异步函数解析或返回的。
-
-该函数将返回一个 updated document，让 `mutate` 更新相应的缓存值。每次调用它时，都可能以某种方式抛出错误。
-
-```jsx
-try {
-  const user = await mutate('/api/user', updateUser(newUser))
-} catch (error) {
-  // 在这里处理更新 user 时的错误
-}
 ```
 
 ## Mutate Multiple Items

--- a/pages/docs/mutation.zh-CN.md
+++ b/pages/docs/mutation.zh-CN.md
@@ -1,11 +1,24 @@
 # 数据更改
 
-## Options
+SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and related cache.
 
-- `optimisticData`：data to immediately update the client cache, or a function that receives current data and returns the new client cache data, usually used in optimistic UI.
-- `revalidate`：一旦完成异步更新，缓存是否重新请求。
-- `populateCache`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
-- `rollbackOnError`：如果远程更新出错，是否进行缓存回滚。
+## mutate
+
+```js
+mutate(key, data, options)
+```
+
+### API
+
+#### Parameters
+
+- `key`: same as `useSWR`'s `key`
+- `data`: data to update the client cache, or an async function for the remote mutation
+- `options`: accepts the following options
+  - `optimisticData(currentData)`: data to immediately update the client cache, or a function that receives current data and returns the new client cache data, usually used in optimistic UI.
+  - `revalidate = true`: should the cache revalidate once the asynchronous update resolves.
+  - `populateCache = true`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
+  - `rollbackOnError = true`: should the cache rollback if the remote mutation errors.
 
 ## 重新验证
 
@@ -227,5 +240,123 @@ function Profile () {
       }}>Uppercase my name!</button>
     </div>
   )
+}
+```
+
+## useSWRMutation
+
+SWR also provides `useSWRMutation` as a hook for remote mutations. The remote mutations are only triggered manually, instead of automatically like `useSWR`.
+
+```jsx
+import useSWRMutation from 'swr/mutation'
+
+async function getData(url, { arg }) {
+  // Fetcher implementation.
+  // The extra argument will be passed via the `arg` property of the 2nd parameter.
+  // For the example below, `arg` will be `'my_token'`
+}
+
+// A useSWR + mutate like API, but it will never start the request.
+const { data, error, trigger, reset, isMutating } = useSWRMutation('/api/user', getData, options?)
+trigger('my_token');
+```
+
+### API
+
+#### Parameters
+
+- `key`:  same as `useSWR`'s `key`
+- `fetcher(key, { arg })`: an async function for remote mutation
+- `options`: accepts the following options
+  - `optimisticData(currentData)`: same as `mutate`'s `optimisticData`
+  - `revalidate = true`: same as `mutate`'s `revalidate`
+  - `populateCache = false`: same as `mutate`'s `populateCache`, but the default is `false`
+  - `rollbackOnError = true`: same as `mutate`'s `rollbackOnError`
+  - `onSuccess(data, key, config)`:　callback function when a remote mutation has been finished successfully
+  - `onError(err, key, config)`: callback function when a remote mutation has returned an error
+
+#### Return Values
+
+- `data`: data for the given key returned from `fetcher`
+- `error`: error thrown by `fetcher` (or undefined)
+- `trigger(arg, options)`: a function to trigger a remote mutation
+- `reset`: a function to reset the state (`data`, `error`, `isMutating`)
+- `isMutating`: if there's an ongoing remote mutation
+
+### Basic Examples
+
+```jsx
+import useSWRMutation from 'swr/mutation'
+
+async function sendRequest(url, { arg }) {
+  return fetch(url, {
+    method: 'POST',
+    body: JSON.stringify(arg)
+  })
+}
+
+function App() {
+  const { trigger } = useSWRMutation('/api/user', sendRequest, /* options */)
+
+  return (
+    <button
+      onClick={async () => {
+        try {
+          const result = await trigger({ username: 'johndoe' }, /* options */)
+        } catch (e) {
+          // error handling
+        }
+      }}
+    >
+      Create User
+    </button>
+  )
+}
+```
+
+If you want to use the mutation results in rendering, you can get them from the return values of `useSWRMutation`.
+
+```jsx
+const { trigger, data, error } = useSWRMutation('/api/user', sendRequest)
+```
+
+`useSWRMutation` shares a cache store with `useSWR`, so it can detect and avoid race conditions between `useSWR`. It also supports `mutate`'s functionalities like optimistic updates and rollback on errors. You can pass these options `useSWRMutation` and its `trigger` function.
+
+```jsx
+const { trigger } = useSWRMutation('/api/user', updateUser, {
+  optimisticData: current => ({ ...current, name: newName })
+})
+
+// or
+
+trigger(newName, {
+  optimisticData: current => ({ ...current, name: newName })
+})
+```
+
+### Defer loading data until needed
+
+You can also use `useSWRMutation` for loading data. `useSWRMutation` never start requesting until `trigger` is called, so you can defer loading data when you actually need it.
+
+```jsx
+import { useState } from 'react'
+import useSWRMutation from 'swr/mutation'
+
+const fetcher = url => fetch(url).then(res => res.json())
+
+const Page = () => {
+  const [show, setShow] = useState(false)
+  // data is undefined until trigger is called
+  const { data: user, trigger } = useSWR('/api/user', fetcher);
+
+  return (
+    <div>
+      <button onClick={() => {
+        trigger();
+        setShow(true);
+      }}>Show User</button>
+      {show && user ? <div>{usre.name}</div> : null}
+    </div>
+  );
 }
 ```


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

This is a follow-up PR of #348, which applies the updates to other languages.
I've also moved a section for return values of `mutate` into `API` section, which makes it easy to find out the return value of `mutate`. https://github.com/vercel/swr-site/commit/9ed2b80712172bc7f40c926d673578ea07184590

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


