### PR TITLE
make explicit the location of mutate

### DIFF
--- a/pages/docs/mutation.en-US.md
+++ b/pages/docs/mutation.en-US.md
@@ -5,16 +5,22 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-import { mutate, useSWRConfig } from "swr"
+import { mutate as globalMutate, useSWRConfig } from "swr"
 
 function App() {
   // Or from the useSWRConfig hook
-  // const { mutate } = useSWRConfig()
-  const data = await mutate(key, data, options)
+  const { mutate } = useSWRConfig()
+  const data = mutate(key, data, options)
+  
+  // Or you can use globalMutate directly
+  // await globalMutate(key, data, options)
+  
 }
 ```
 
-You can get [bound mutate](/docs/mutation#bound-mutate) from `useSWR`.
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data
+
+#### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)

--- a/pages/docs/mutation.en-US.md
+++ b/pages/docs/mutation.en-US.md
@@ -5,7 +5,19 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-const data = await mutate(key, data, options)
+import { mutate, useSWRConfig } from "swr"
+
+function App() {
+  // Or from the useSWRConfig hook
+  // const { mutate } = useSWRConfig()
+  const data = await mutate(key, data, options)
+}
+```
+
+You can get [bound mutate](/docs/mutation#bound-mutate) from `useSWR`.
+
+```js
+const { mutate } = useSWR(key, fetcher)
 ```
 
 ### API

--- a/pages/docs/mutation.en-US.md
+++ b/pages/docs/mutation.en-US.md
@@ -4,6 +4,10 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 
 ## mutate
 
+There're 2 ways to use the `mutate` API to mutate the data, the global mutate API which can mutate any key and the bound mutate API which only can mutate the data of corresponding SWR hook.
+
+#### Global Mutate
+
 ```js
 import { mutate as globalMutate, useSWRConfig } from "swr"
 
@@ -16,13 +20,15 @@ function App() {
 
 }
 ```
+#### Bound Mutate
 
-[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data.
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data. Which `key` is bounded to the `key` passing to SWR, and receive the `data` as the first argument.
 
-### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)
+
+await mutate(data)
 ```
 
 ### API

--- a/pages/docs/mutation.en-US.md
+++ b/pages/docs/mutation.en-US.md
@@ -8,19 +8,18 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 import { mutate as globalMutate, useSWRConfig } from "swr"
 
 function App() {
-  // Or from the useSWRConfig hook
   const { mutate } = useSWRConfig()
   const data = mutate(key, data, options)
-  
+
   // Or you can use globalMutate directly
   // await globalMutate(key, data, options)
-  
+
 }
 ```
 
-[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data.
 
-#### Example
+### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)

--- a/pages/docs/mutation.es-ES.md
+++ b/pages/docs/mutation.es-ES.md
@@ -5,7 +5,19 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-const data = await mutate(key, data, options)
+import { mutate, useSWRConfig } from "swr"
+
+function App() {
+  // Or from the useSWRConfig hook
+  // const { mutate } = useSWRConfig()
+  const data = await mutate(key, data, options)
+}
+```
+
+You can get [bound mutate](/docs/mutation#bound-mutate) from `useSWR`.
+
+```js
+const { mutate } = useSWR(key, fetcher)
 ```
 
 ### API

--- a/pages/docs/mutation.es-ES.md
+++ b/pages/docs/mutation.es-ES.md
@@ -4,6 +4,10 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 
 ## mutate
 
+There're 2 ways to use the `mutate` API to mutate the data, the global mutate API which can mutate any key and the bound mutate API which only can mutate the data of corresponding SWR hook.
+
+#### Global Mutate
+
 ```js
 import { mutate as globalMutate, useSWRConfig } from "swr"
 
@@ -16,13 +20,15 @@ function App() {
 
 }
 ```
+#### Bound Mutate
 
-[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data.
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data. Which `key` is bounded to the `key` passing to SWR, and receive the `data` as the first argument.
 
-### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)
+
+await mutate(data)
 ```
 
 ### API

--- a/pages/docs/mutation.es-ES.md
+++ b/pages/docs/mutation.es-ES.md
@@ -5,16 +5,21 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-import { mutate, useSWRConfig } from "swr"
+import { mutate as globalMutate, useSWRConfig } from "swr"
 
 function App() {
-  // Or from the useSWRConfig hook
-  // const { mutate } = useSWRConfig()
-  const data = await mutate(key, data, options)
+  const { mutate } = useSWRConfig()
+  const data = mutate(key, data, options)
+
+  // Or you can use globalMutate directly
+  // await globalMutate(key, data, options)
+
 }
 ```
 
-You can get [bound mutate](/docs/mutation#bound-mutate) from `useSWR`.
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data.
+
+### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)

--- a/pages/docs/mutation.ja.md
+++ b/pages/docs/mutation.ja.md
@@ -4,6 +4,10 @@ SWR はリモートデータ及びキャッシュデータの更新のために 
 
 ## mutate
 
+There're 2 ways to use the `mutate` API to mutate the data, the global mutate API which can mutate any key and the bound mutate API which only can mutate the data of corresponding SWR hook.
+
+#### Global Mutate
+
 ```js
 import { mutate as globalMutate, useSWRConfig } from "swr"
 
@@ -16,13 +20,15 @@ function App() {
 
 }
 ```
+#### Bound Mutate
 
-[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data.
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data. Which `key` is bounded to the `key` passing to SWR, and receive the `data` as the first argument.
 
-### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)
+
+await mutate(data)
 ```
 
 ### API

--- a/pages/docs/mutation.ja.md
+++ b/pages/docs/mutation.ja.md
@@ -5,7 +5,19 @@ SWR はリモートデータ及びキャッシュデータの更新のために 
 ## mutate
 
 ```js
-const data = await mutate(key, data, options)
+import { mutate, useSWRConfig } from "swr"
+
+function App() {
+  // Or from the useSWRConfig hook
+  // const { mutate } = useSWRConfig()
+  const data = await mutate(key, data, options)
+}
+```
+
+You can get [bound mutate](/docs/mutation#bound-mutate) from `useSWR`.
+
+```js
+const { mutate } = useSWR(key, fetcher)
 ```
 
 ### API

--- a/pages/docs/mutation.ja.md
+++ b/pages/docs/mutation.ja.md
@@ -5,16 +5,21 @@ SWR はリモートデータ及びキャッシュデータの更新のために 
 ## mutate
 
 ```js
-import { mutate, useSWRConfig } from "swr"
+import { mutate as globalMutate, useSWRConfig } from "swr"
 
 function App() {
-  // Or from the useSWRConfig hook
-  // const { mutate } = useSWRConfig()
-  const data = await mutate(key, data, options)
+  const { mutate } = useSWRConfig()
+  const data = mutate(key, data, options)
+
+  // または globalMutate を直接使うこともできます
+  // await globalMutate(key, data, options)
+
 }
 ```
 
-You can get [bound mutate](/docs/mutation#bound-mutate) from `useSWR`.
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data.
+
+### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)

--- a/pages/docs/mutation.ko.md
+++ b/pages/docs/mutation.ko.md
@@ -4,6 +4,10 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 
 ## mutate
 
+There're 2 ways to use the `mutate` API to mutate the data, the global mutate API which can mutate any key and the bound mutate API which only can mutate the data of corresponding SWR hook.
+
+#### Global Mutate
+
 ```js
 import { mutate as globalMutate, useSWRConfig } from "swr"
 
@@ -16,13 +20,15 @@ function App() {
 
 }
 ```
+#### Bound Mutate
 
-[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data.
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data. Which `key` is bounded to the `key` passing to SWR, and receive the `data` as the first argument.
 
-### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)
+
+await mutate(data)
 ```
 
 ### API
@@ -145,7 +151,7 @@ function Profile () {
 
 현재 데이터를 기반으로 데이터의 일부를 업데이트하려는 경우가 있습니다.
 
-`mutate`를 사용해 현재 캐시 된 값을 받는(있으면 업데이트된 문서를 반환) 비동기 함수를 전달할 수 있습니다. 
+`mutate`를 사용해 현재 캐시 된 값을 받는(있으면 업데이트된 문서를 반환) 비동기 함수를 전달할 수 있습니다.
 
 ```jsx
 mutate('/api/todos', async todos => {

--- a/pages/docs/mutation.ko.md
+++ b/pages/docs/mutation.ko.md
@@ -5,7 +5,19 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-const data = await mutate(key, data, options)
+import { mutate, useSWRConfig } from "swr"
+
+function App() {
+  // Or from the useSWRConfig hook
+  // const { mutate } = useSWRConfig()
+  const data = await mutate(key, data, options)
+}
+```
+
+You can get [bound mutate](/docs/mutation#bound-mutate) from `useSWR`.
+
+```js
+const { mutate } = useSWR(key, fetcher)
 ```
 
 ### API

--- a/pages/docs/mutation.ko.md
+++ b/pages/docs/mutation.ko.md
@@ -5,16 +5,21 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-import { mutate, useSWRConfig } from "swr"
+import { mutate as globalMutate, useSWRConfig } from "swr"
 
 function App() {
-  // Or from the useSWRConfig hook
-  // const { mutate } = useSWRConfig()
-  const data = await mutate(key, data, options)
+  const { mutate } = useSWRConfig()
+  const data = mutate(key, data, options)
+
+  // Or you can use globalMutate directly
+  // await globalMutate(key, data, options)
+
 }
 ```
 
-You can get [bound mutate](/docs/mutation#bound-mutate) from `useSWR`.
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data.
+
+### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)

--- a/pages/docs/mutation.pt-BR.md
+++ b/pages/docs/mutation.pt-BR.md
@@ -5,7 +5,19 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-const data = await mutate(key, data, options)
+import { mutate, useSWRConfig } from "swr"
+
+function App() {
+  // Or from the useSWRConfig hook
+  // const { mutate } = useSWRConfig()
+  const data = await mutate(key, data, options)
+}
+```
+
+You can get [bound mutate](/docs/mutation#bound-mutate) from `useSWR`.
+
+```js
+const { mutate } = useSWR(key, fetcher)
 ```
 
 ### API

--- a/pages/docs/mutation.pt-BR.md
+++ b/pages/docs/mutation.pt-BR.md
@@ -4,6 +4,10 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 
 ## mutate
 
+There're 2 ways to use the `mutate` API to mutate the data, the global mutate API which can mutate any key and the bound mutate API which only can mutate the data of corresponding SWR hook.
+
+#### Global Mutate
+
 ```js
 import { mutate as globalMutate, useSWRConfig } from "swr"
 
@@ -16,13 +20,15 @@ function App() {
 
 }
 ```
+#### Bound Mutate
 
-[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data.
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data. Which `key` is bounded to the `key` passing to SWR, and receive the `data` as the first argument.
 
-### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)
+
+await mutate(data)
 ```
 
 ### API

--- a/pages/docs/mutation.pt-BR.md
+++ b/pages/docs/mutation.pt-BR.md
@@ -5,16 +5,21 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-import { mutate, useSWRConfig } from "swr"
+import { mutate as globalMutate, useSWRConfig } from "swr"
 
 function App() {
-  // Or from the useSWRConfig hook
-  // const { mutate } = useSWRConfig()
-  const data = await mutate(key, data, options)
+  const { mutate } = useSWRConfig()
+  const data = mutate(key, data, options)
+
+  // Or you can use globalMutate directly
+  // await globalMutate(key, data, options)
+
 }
 ```
 
-You can get [bound mutate](/docs/mutation#bound-mutate) from `useSWR`.
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data.
+
+### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)

--- a/pages/docs/mutation.ru.md
+++ b/pages/docs/mutation.ru.md
@@ -4,6 +4,10 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 
 ## mutate
 
+There're 2 ways to use the `mutate` API to mutate the data, the global mutate API which can mutate any key and the bound mutate API which only can mutate the data of corresponding SWR hook.
+
+#### Global Mutate
+
 ```js
 import { mutate as globalMutate, useSWRConfig } from "swr"
 
@@ -16,15 +20,16 @@ function App() {
 
 }
 ```
+#### Bound Mutate
 
-[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data.
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data. Which `key` is bounded to the `key` passing to SWR, and receive the `data` as the first argument.
 
-### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)
-```
 
+await mutate(data)
+```
 ### API
 
 #### Parameters

--- a/pages/docs/mutation.ru.md
+++ b/pages/docs/mutation.ru.md
@@ -5,7 +5,19 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-const data = await mutate(key, data, options)
+import { mutate, useSWRConfig } from "swr"
+
+function App() {
+  // Or from the useSWRConfig hook
+  // const { mutate } = useSWRConfig()
+  const data = await mutate(key, data, options)
+}
+```
+
+You can get [bound mutate](/docs/mutation#bound-mutate) from `useSWR`.
+
+```js
+const { mutate } = useSWR(key, fetcher)
 ```
 
 ### API

--- a/pages/docs/mutation.ru.md
+++ b/pages/docs/mutation.ru.md
@@ -5,16 +5,21 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-import { mutate, useSWRConfig } from "swr"
+import { mutate as globalMutate, useSWRConfig } from "swr"
 
 function App() {
-  // Or from the useSWRConfig hook
-  // const { mutate } = useSWRConfig()
-  const data = await mutate(key, data, options)
+  const { mutate } = useSWRConfig()
+  const data = mutate(key, data, options)
+
+  // Or you can use globalMutate directly
+  // await globalMutate(key, data, options)
+
 }
 ```
 
-You can get [bound mutate](/docs/mutation#bound-mutate) from `useSWR`.
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data.
+
+### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)

--- a/pages/docs/mutation.zh-CN.md
+++ b/pages/docs/mutation.zh-CN.md
@@ -5,7 +5,19 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-const data = await mutate(key, data, options)
+import { mutate, useSWRConfig } from "swr"
+
+function App() {
+  // Or from the useSWRConfig hook
+  // const { mutate } = useSWRConfig()
+  const data = await mutate(key, data, options)
+}
+```
+
+You can get [bound mutate](/docs/mutation#bound-mutate) from `useSWR`.
+
+```js
+const { mutate } = useSWR(key, fetcher)
 ```
 
 ### API

--- a/pages/docs/mutation.zh-CN.md
+++ b/pages/docs/mutation.zh-CN.md
@@ -4,6 +4,10 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 
 ## mutate
 
+There're 2 ways to use the `mutate` API to mutate the data, the global mutate API which can mutate any key and the bound mutate API which only can mutate the data of corresponding SWR hook.
+
+#### Global Mutate
+
 ```js
 import { mutate as globalMutate, useSWRConfig } from "swr"
 
@@ -16,13 +20,15 @@ function App() {
 
 }
 ```
+#### Bound Mutate
 
-[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data.
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data. Which `key` is bounded to the `key` passing to SWR, and receive the `data` as the first argument.
 
-### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)
+
+await mutate(data)
 ```
 
 ### API

--- a/pages/docs/mutation.zh-CN.md
+++ b/pages/docs/mutation.zh-CN.md
@@ -5,16 +5,21 @@ SWR provides the `mutate` and `useSWRMutation` APIs for mutating remote data and
 ## mutate
 
 ```js
-import { mutate, useSWRConfig } from "swr"
+import { mutate as globalMutate, useSWRConfig } from "swr"
 
 function App() {
-  // Or from the useSWRConfig hook
-  // const { mutate } = useSWRConfig()
-  const data = await mutate(key, data, options)
+  const { mutate } = useSWRConfig()
+  const data = mutate(key, data, options)
+
+  // Or you can use globalMutate directly
+  // await globalMutate(key, data, options)
+
 }
 ```
 
-You can get [bound mutate](/docs/mutation#bound-mutate) from `useSWR`.
+[Bound Mutate](/docs/mutation#bound-mutate) is the short path to mutate the current key with data.
+
+### Example
 
 ```js
 const { mutate } = useSWR(key, fetcher)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

This makes explicit the location where `mutate` can be imported. I've also mentioned a bound mutate function on top of the page.

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


