### PR TITLE
Update docs to provide reliable snippets on custom cache provider

### DIFF
--- a/pages/docs/advanced/cache.en-US.mdx
+++ b/pages/docs/advanced/cache.en-US.mdx
@@ -37,8 +37,9 @@ The `provider` option of `SWRConfig` receives a function that returns a [cache p
 import useSWR, { SWRConfig } from 'swr'
 
 function App() {
+  const cache = new Map()
   return (
-    <SWRConfig value={{ provider: () => new Map() }}>
+    <SWRConfig value={{ provider: () => cache }}>
       <Page/>
     </SWRConfig>
   )
@@ -162,7 +163,9 @@ function localStorageProvider() {
 Then use it as a provider:
 
 ```jsx
-<SWRConfig value={{ provider: localStorageProvider }}>
+const cache = localStorageProvider()
+...
+<SWRConfig value={{ provider: () => cache }}>
   <App/>
 </SWRConfig>
 ```


### PR DESCRIPTION
Following the instructions on this page verbatim is not reliable. Using the format:

```javascript
<SWRConfig value={{ provider: () => new Map() }}>
    ...
</SWRConfig>
```

The cache is garbage collected immediately, causes the whole app to crash. Ref: https://github.com/vercel/swr/issues/2125 (Could this be as a results of using `WeakMap`

Even though it's stated here [cache.en-US.mdx#L50-L52](https://github.com/vercel/swr-site/blob/57991d1b50c3c984c0dd5bd86e25085b9c8cf235/pages/docs/advanced/cache.en-US.mdx?plain=1#L50-L52) it's very easy to miss it. And I think a lot of people follow through docs with section titles and code snippets (myself at least)

I experienced this personally (lost some hours) and had to dig into the source code really understand why my code wasn't working meanwhile it was suggested in the docs.

This a repl reproducing the issue: https://replit.com/@blackmann/SparklingCompassionateSolaris#src/App.jsx

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


