### PR TITLE
fix variable typo in mutation documentation

### DIFF
--- a/pages/docs/mutation.en-US.md
+++ b/pages/docs/mutation.en-US.md
@@ -246,7 +246,7 @@ const Page = () => {
         trigger();
         setShow(true);
       }}>Show User</button>
-      {show && user ? <div>{usre.name}</div> : null}
+      {show && user ? <div>{user.name}</div> : null}
     </div>
   );
 }

--- a/pages/docs/mutation.es-ES.md
+++ b/pages/docs/mutation.es-ES.md
@@ -246,7 +246,7 @@ const Page = () => {
         trigger();
         setShow(true);
       }}>Show User</button>
-      {show && user ? <div>{usre.name}</div> : null}
+      {show && user ? <div>{user.name}</div> : null}
     </div>
   );
 }

--- a/pages/docs/mutation.ja.md
+++ b/pages/docs/mutation.ja.md
@@ -247,7 +247,7 @@ const Page = () => {
         trigger();
         setShow(true);
       }}>Show User</button>
-      {show && user ? <div>{usre.name}</div> : null}
+      {show && user ? <div>{user.name}</div> : null}
     </div>
   );
 }

--- a/pages/docs/mutation.ko.md
+++ b/pages/docs/mutation.ko.md
@@ -246,7 +246,7 @@ const Page = () => {
         trigger();
         setShow(true);
       }}>Show User</button>
-      {show && user ? <div>{usre.name}</div> : null}
+      {show && user ? <div>{user.name}</div> : null}
     </div>
   );
 }

--- a/pages/docs/mutation.pt-BR.md
+++ b/pages/docs/mutation.pt-BR.md
@@ -246,7 +246,7 @@ const Page = () => {
         trigger();
         setShow(true);
       }}>Show User</button>
-      {show && user ? <div>{usre.name}</div> : null}
+      {show && user ? <div>{user.name}</div> : null}
     </div>
   );
 }

--- a/pages/docs/mutation.ru.md
+++ b/pages/docs/mutation.ru.md
@@ -246,7 +246,7 @@ const Page = () => {
         trigger();
         setShow(true);
       }}>Show User</button>
-      {show && user ? <div>{usre.name}</div> : null}
+      {show && user ? <div>{user.name}</div> : null}
     </div>
   );
 }

--- a/pages/docs/mutation.zh-CN.md
+++ b/pages/docs/mutation.zh-CN.md
@@ -246,7 +246,7 @@ const Page = () => {
         trigger();
         setShow(true);
       }}>Show User</button>
-      {show && user ? <div>{usre.name}</div> : null}
+      {show && user ? <div>{user.name}</div> : null}
     </div>
   );
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates

Fixes a typo in a variable name in the documentation for `mutation`
