### PR TITLE
[swr-Docs: Argument] Typo fix

### DIFF
--- a/pages/docs/arguments.en-US.md
+++ b/pages/docs/arguments.en-US.md
@@ -26,7 +26,7 @@ Instead, you can use an **array** as the `key` parameter, which contains multipl
 const { data: user } = useSWR(['/api/user', token], ([url, token]) => fetchWithToken(url, token))
 ```
 
-The `fetcher` function accepts the `key` parameter as is, and the cache key will also be associated with the entire `key` argument. In the above example, `url` and `token` are both tight to the cache key.
+The `fetcher` function accepts the `key` parameter as is, and the cache key will also be associated with the entire `key` argument. In the above example, `url` and `token` are both tied to the cache key.
 
 <Callout emoji="⚠️">
   In the previous versions (< 2.0.0), The `fetcher` function will receive the spreaded arguments from original `key` when the `key` argument is array type. E.g., key `[url, token]` will become 2 arguments `(url, token)` for `fetcher` function.


### PR DESCRIPTION
"In the above example, `url` and `token` are both _tight_ to the cache key." 

"In the above example, `url` and `token` are both _tied_ to the cache key."

```diff
- tight
+ tied
```

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


