### PR TITLE
docs: Fix typo in `understanding.ja.mdx`

### DIFF
--- a/pages/docs/advanced/understanding.ja.mdx
+++ b/pages/docs/advanced/understanding.ja.mdx
@@ -120,6 +120,6 @@ function Search() {
 
 この例のコードはこちらです: https://codesandbox.io/s/swr-keeppreviousdata-fsjz3m.
 
-## パフォーマンのための依存収集
+## パフォーマンスのための依存収集
 
 SWR はコンポーネントで使われているデータが更新された場合のみ再レンダリングします。コンポーネントの中で `data` しか使っていない場合、SWR は `isValidating` や `isLoading` のプロパティの更新を無視します。これはレンダリングの回数を減らします。詳細については [こちら](/docs/advanced/performance#dependency-collection)。


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates

This PR is fixed a typo section title in `understanding.ja.mdx`.
This page which is based of a English page exists "[Understanding SWR](https://swr.vercel.app/docs/advanced/understanding)". The target section title for English pages is "[Dependency Collection for performance](https://swr.vercel.app/docs/advanced/understanding#dependency-collection-for-performance)".

