### PR TITLE
docs: fix hooks destructure typo error in clear all cache code examples

### DIFF
--- a/pages/docs/advanced/cache.en-US.mdx
+++ b/pages/docs/advanced/cache.en-US.mdx
@@ -197,7 +197,7 @@ describe('test suite', async () => {
 You can use [`mutate`](/docs/mutation) to modify the cache. For example, you can clear all cache data like the following.
 
 ```jsx
-const { cache } = useSWRConfig()
+const { mutate } = useSWRConfig()
 
 mutate(
   key => true, // which cache keys are updated

--- a/pages/docs/advanced/cache.ja.mdx
+++ b/pages/docs/advanced/cache.ja.mdx
@@ -203,7 +203,7 @@ cache.get(key) // キーの現在のデータを取得します。
 [`mutate`](/docs/mutation) をキャッシュを更新するために利用できます。例えば、下記のようにすることで全てのキャッシュデータをクリアできます。
 
 ```jsx
-const { cache } = useSWRConfig()
+const { mutate } = useSWRConfig()
 
 mutate(
   key => true, // どのキャッシュキーを更新するか

--- a/pages/docs/advanced/cache.ko.mdx
+++ b/pages/docs/advanced/cache.ko.mdx
@@ -203,7 +203,7 @@ cache.get(key) // 키에 대한 현재 데이터 가져오기.
 You can use [`mutate`](/docs/mutation) to modify the cache. For example, you can clear all cache data like the following.
 
 ```jsx
-const { cache } = useSWRConfig()
+const { mutate } = useSWRConfig()
 
 mutate(
   key => true, // which cache keys are updated

--- a/pages/docs/advanced/cache.pt-BR.mdx
+++ b/pages/docs/advanced/cache.pt-BR.mdx
@@ -206,7 +206,7 @@ cache.get(key) // Obtém os dados atuais para uma chave.
 You can use [`mutate`](/docs/mutation) to modify the cache. For example, you can clear all cache data like the following.
 
 ```jsx
-const { cache } = useSWRConfig()
+const { mutate } = useSWRConfig()
 
 mutate(
   key => true, // which cache keys are updated

--- a/pages/docs/advanced/cache.ru.mdx
+++ b/pages/docs/advanced/cache.ru.mdx
@@ -220,7 +220,7 @@ cache.get(key) // Получить текущие данные для ключа
 Вы можете использовать [`mutate`](/docs/mutation) для модификации кеша. Например, вы можете очистить все данные кеша, как показано ниже.
 
 ```jsx
-const { cache } = useSWRConfig()
+const { mutate } = useSWRConfig()
 
 mutate(
   key => true, // какие ключи кеша обновляются

--- a/pages/docs/advanced/cache.zh-CN.mdx
+++ b/pages/docs/advanced/cache.zh-CN.mdx
@@ -197,7 +197,7 @@ describe('test suite', async () => {
 You can use [`mutate`](/docs/mutation) to modify the cache. For example, you can clear all cache data like the following.
 
 ```jsx
-const { cache } = useSWRConfig()
+const { mutate } = useSWRConfig()
 
 mutate(
   key => true, // which cache keys are updated


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.

### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description
[This code example](https://swr.vercel.app/ko/docs/advanced/cache#modify-the-cache-data) shows how to clear cache with the ```mutate``` function.

However, The ```cache``` object is deconstructed instead of the ```mutate``` function.

So It have to replace with the ```mutate``` function instead of the ```cache``` object

***This PR changed all languages.***

<!-- What're you changing? -->

- [ ] Adding new page
- [X] Updating existing documentation
- [ ] Other updates


