### PR TITLE
docs: remove the Mutate Multiple Keys from RegEx section in the Cache…

### DIFF
--- a/pages/docs/advanced/cache.en-US.mdx
+++ b/pages/docs/advanced/cache.en-US.mdx
@@ -97,49 +97,6 @@ The first argument for the `provider` function is the cache provider of the uppe
 
 ## Examples
 
-### Mutate Multiple Keys from RegEx
-
-With the flexibility of the cache provider API, you can even build a "partial mutation" helper.
-
-In the example below, `matchMutate` can receive a regex expression as key, and be used to mutate the ones who matched this pattern.
-
-```js
-function useMatchMutate() {
-  const { cache, mutate } = useSWRConfig()
-  return (matcher, ...args) => {
-    if (!(cache instanceof Map)) {
-      throw new Error('matchMutate requires the cache provider to be a Map instance')
-    }
-
-    const keys = []
-
-    for (const key of cache.keys()) {
-      if (matcher.test(key)) {
-        keys.push(key)
-      }
-    }
-
-    const mutations = keys.map((key) => mutate(key, ...args))
-    return Promise.all(mutations)
-  }
-}
-```
-
-Then inside your component:
-
-```jsx
-function Button() {
-  const matchMutate = useMatchMutate()
-  return <button onClick={() => matchMutate(/^\/api\//)}>
-    Revalidate all keys start with "/api/"
-  </button>
-}
-```
-
-<Callout>
-  Note that this example requires the cache provider to be a Map instance.
-</Callout>
-
 ### LocalStorage Based Persistent Cache
 
 You might want to sync your cache to `localStorage`. Here's an example implementation:

--- a/pages/docs/advanced/cache.ja.mdx
+++ b/pages/docs/advanced/cache.ja.mdx
@@ -97,49 +97,6 @@ function Avatar() {
 
 ## 例
 
-### 正規表現から複数のキーを変更する
-
-キャッシュプロバイダー API の柔軟性により、"部分的な変更"のヘルパーを構築することもできます。
-
-以下の例では、 `matchMutate` はキーとして正規表現を受け取り、パターンに一致するものを変更するために使用できます。
-
-```js
-function useMatchMutate() {
-  const { cache, mutate } = useSWRConfig()
-  return (matcher, ...args) => {
-    if (!(cache instanceof Map)) {
-      throw new Error('matchMutate requires the cache provider to be a Map instance')
-    }
-
-    const keys = []
-
-    for (const key of cache.keys()) {
-      if (matcher.test(key)) {
-        keys.push(key)
-      }
-    }
-
-    const mutations = keys.map((key) => mutate(key, ...args))
-    return Promise.all(mutations)
-  }
-}
-```
-
-次に、コンポーネントの内部：
-
-```jsx
-function Button() {
-  const matchMutate = useMatchMutate()
-  return <button onClick={() => matchMutate(/^\/api\//)}>
-    Revalidate all keys start with "/api/"
-  </button>
-}
-```
-
-<Callout>
-  この例では、キャッシュプロバイダーが Map インスタンスである必要があることに注意してください。
-</Callout>
-
 ### LocalStorage を使った永続キャッシュ
 
 キャッシュを `localStorage` で同期しても良いかもしれません。実装例は次の通りです：

--- a/pages/docs/advanced/cache.ko.mdx
+++ b/pages/docs/advanced/cache.ko.mdx
@@ -97,49 +97,6 @@ function Avatar() {
 
 ## 예시
 
-### RegEx로 여러 키 변경하기
-
-캐시 공급자 API의 유연성으로, "부분 변경" 헬퍼를 구축할 수도 있습니다.
-
-아래 예시에서는 `matchMutate`가 정규 표현식을 키로 받고, 이 패턴에 일치하는 것들을 변경하는데 사용할 수 있습니다.
-
-```js
-function useMatchMutate() {
-  const { cache, mutate } = useSWRConfig()
-  return (matcher, ...args) => {
-    if (!(cache instanceof Map)) {
-      throw new Error('matchMutate requires the cache provider to be a Map instance')
-    }
-
-    const keys = []
-
-    for (const key of cache.keys()) {
-      if (matcher.test(key)) {
-        keys.push(key)
-      }
-    }
-
-    const mutations = keys.map((key) => mutate(key, ...args))
-    return Promise.all(mutations)
-  }
-}
-```
-
-그 후 여러분의 컴포넌트 내에서:
-
-```jsx
-function Button() {
-  const matchMutate = useMatchMutate()
-  return <button onClick={() => matchMutate(/^\/api\//)}>
-    Revalidate all keys start with "/api/"
-  </button>
-}
-```
-
-<Callout>
-  이 예시는 캐시 공급자가 Map 인스턴스여야 합니다.
-</Callout>
-
 ### LocalStorage 기반 영구 캐시
 
 캐시를 `localStorage`와 동기화하길 원할 수도 있습니다. 다음은 구현 예시입니다.

--- a/pages/docs/advanced/cache.pt-BR.mdx
+++ b/pages/docs/advanced/cache.pt-BR.mdx
@@ -100,49 +100,6 @@ O primeiro argumento para a função `provider` é o cache provider do nível su
 
 ## Exemplos
 
-### Mudar Várias Chaves de RegEx
-
-Com a flexibilidade da API do cache provider, você pode até criar um auxiliar de "mutação parcial".
-
-No exemplo abaixo, `matchMutate` pode receber uma expressão regular como chave e ser usada para alterar aqueles que corresponderem a esse padrão.
-
-```js
-function useMatchMutate() {
-  const { cache, mutate } = useSWRConfig()
-  return (matcher, ...args) => {
-    if (!(cache instanceof Map)) {
-      throw new Error('matchMutate requer que o cache provider seja uma instância de Map')
-    }
-
-    const keys = []
-
-    for (const key of cache.keys()) {
-      if (matcher.test(key)) {
-        keys.push(key)
-      }
-    }
-
-    const mutations = keys.map((key) => mutate(key, ...args))
-    return Promise.all(mutations)
-  }
-}
-```
-
-Em seguida, dentro de seu componente:
-
-```jsx
-function Button() {
-  const matchMutate = useMatchMutate()
-  return <button onClick={() => matchMutate(/^\/api\//)}>
-    Revalidar todas as chaves começando com "/api/"
-  </button>
-}
-```
-
-<Callout>
-  Observe que este exemplo requer que o cache provider seja uma instância de Map.
-</Callout>
-
 ### Cache Persistente Baseado em LocalStorage
 
 Você pode querer sincronizar seu cache com `localStorage`. Aqui está um exemplo de implementação:

--- a/pages/docs/advanced/cache.ru.mdx
+++ b/pages/docs/advanced/cache.ru.mdx
@@ -110,50 +110,6 @@ function Avatar() {
 
 ## Примеры
 
-### Мутация множества ключей из регулярных выражений (RegEx)
-
-Благодаря гибкости API кеш-провайдера вы даже можете создать помощник «частичной мутации».
-
-В приведенном ниже примере `matchMutate` может принимать регулярное выражение в качестве ключа
-и использоваться для мутации тех, кто соответствует этому шаблону.
-
-```js
-function useMatchMutate() {
-  const { cache, mutate } = useSWRConfig()
-  return (matcher, ...args) => {
-    if (!(cache instanceof Map)) {
-      throw new Error('matchMutate требует, чтобы провайдер кеша был экземпляром Map')
-    }
-
-    const keys = []
-
-    for (const key of cache.keys()) {
-      if (matcher.test(key)) {
-        keys.push(key)
-      }
-    }
-
-    const mutations = keys.map((key) => mutate(key, ...args))
-    return Promise.all(mutations)
-  }
-}
-```
-
-Затем внутри вашего компонента:
-
-```jsx
-function Button() {
-  const matchMutate = useMatchMutate()
-  return <button onClick={() => matchMutate(/^\/api\//)}>
-    Ревалидировать все ключи, начинающиеся на "/api/"
-  </button>
-}
-```
-
-<Callout>
-  Обратите внимание, что данный пример требует, чтобы провайдер кеша был экземпляром Map.
-</Callout>
-
 ### Постоянный кеш на основе LocalStorage
 
 Возможно, вы захотите синхронизировать свой кеш с `localStorage`. Вот пример реализации:

--- a/pages/docs/advanced/cache.zh-CN.mdx
+++ b/pages/docs/advanced/cache.zh-CN.mdx
@@ -97,49 +97,6 @@ function Avatar() {
 
 ## 示例
 
-### 根据正则更改多个 Key
-
-借助缓存 provider API 的灵活性，你甚至可以构建一个“部分更改”的助手函数。
-
-在下面的示例中，`matchMutate` 可以接收一个正则表达式作为 key，并用于更改匹配该模式的。
-
-```js
-function useMatchMutate() {
-  const { cache, mutate } = useSWRConfig()
-  return (matcher, ...args) => {
-    if (!(cache instanceof Map)) {
-      throw new Error('matchMutate requires the cache provider to be a Map instance')
-    }
-
-    const keys = []
-
-    for (const key of cache.keys()) {
-      if (matcher.test(key)) {
-        keys.push(key)
-      }
-    }
-
-    const mutations = keys.map((key) => mutate(key, ...args))
-    return Promise.all(mutations)
-  }
-}
-```
-
-在你的组件内：
-
-```jsx
-function Button() {
-  const matchMutate = useMatchMutate()
-  return <button onClick={() => matchMutate(/^\/api\//)}>
-    重新请求所有以 `/api/` 开头的 key
-  </button>
-}
-```
-
-<Callout>
-  注意，该示例要求缓存 provider 为 Map 实例。
-</Callout>
-
 ### 基于 LocalStorage 的持久缓存
 
 你可能希望将缓存同步到 `localStorage`。下面是一个示例实现：


### PR DESCRIPTION


<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

We recommend using [Mutate multiple items](https://swr.vercel.app/docs/mutation#mutate-multiple-items) instead of modifying `cache` directly.

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


