### PR TITLE
docs: fix typo swr/infinte -> swr/infinite

### DIFF
--- a/pages/docs/pagination.en-US.mdx
+++ b/pages/docs/pagination.en-US.mdx
@@ -316,7 +316,7 @@ const getKey = (pageIndex, previousPageData) => {
 
 ### Global Mutate with `useSWRInfinite`
 
-`useSWRInfinite` stores all page data into the cache with a special cache key along with each page data, so you have to use `unstable_serialize` in `swr/infintie` to revalidate the data with the global mutate.
+`useSWRInfinite` stores all page data into the cache with a special cache key along with each page data, so you have to use `unstable_serialize` in `swr/infinite` to revalidate the data with the global mutate.
 
 ```jsx
 import { useSWRConfig } from "swr"
@@ -326,7 +326,7 @@ function App() {
     const { mutate } = useSWRConfig()
     mutate(unstable_serialize(getKey))
 }
-````
+```
 
 <Callout emoji="⚠️">
     As the name implies, `unstable_serialize` is not a stable API, so we might change it in the future.

--- a/pages/docs/pagination.en-US.mdx
+++ b/pages/docs/pagination.en-US.mdx
@@ -320,7 +320,7 @@ const getKey = (pageIndex, previousPageData) => {
 
 ```jsx
 import { useSWRConfig } from "swr"
-import { unstable_serialize } from "swr/infinte"
+import { unstable_serialize } from "swr/infinite"
 
 function App() {
     const { mutate } = useSWRConfig()

--- a/pages/docs/pagination.es-ES.mdx
+++ b/pages/docs/pagination.es-ES.mdx
@@ -318,7 +318,7 @@ const getKey = (pageIndex, previousPageData) => {
 
 ### Global Mutate with `useSWRInfinite`
 
-`useSWRInfinite` stores all page data into the cache with a special cache key along with each page data, so you have to use `unstable_serialize` in `swr/infintie` to revalidate the data with the global mutate.
+`useSWRInfinite` stores all page data into the cache with a special cache key along with each page data, so you have to use `unstable_serialize` in `swr/infinite` to revalidate the data with the global mutate.
 
 ```jsx
 import { useSWRConfig } from "swr"
@@ -328,7 +328,7 @@ function App() {
     const { mutate } = useSWRConfig()
     mutate(unstable_serialize(getKey))
 }
-````
+```
 
 <Callout emoji="⚠️">
     As the name implies, `unstable_serialize` is not a stable API, so we might change it in the future.

--- a/pages/docs/pagination.es-ES.mdx
+++ b/pages/docs/pagination.es-ES.mdx
@@ -322,7 +322,7 @@ const getKey = (pageIndex, previousPageData) => {
 
 ```jsx
 import { useSWRConfig } from "swr"
-import { unstable_serialize } from "swr/infinte"
+import { unstable_serialize } from "swr/infinite"
 
 function App() {
     const { mutate } = useSWRConfig()

--- a/pages/docs/pagination.ja.mdx
+++ b/pages/docs/pagination.ja.mdx
@@ -320,7 +320,7 @@ const getKey = (pageIndex, previousPageData) => {
 
 ```jsx
 import { useSWRConfig } from "swr"
-import { unstable_serialize } from "swr/infinte"
+import { unstable_serialize } from "swr/infinite"
 
 function App() {
     const { mutate } = useSWRConfig()

--- a/pages/docs/pagination.ja.mdx
+++ b/pages/docs/pagination.ja.mdx
@@ -316,7 +316,7 @@ const getKey = (pageIndex, previousPageData) => {
 
 ### Global Mutate with `useSWRInfinite`
 
-`useSWRInfinite` は各ページのデータに加え、全てのページデータを特別な形式のキーでキャッシュに保存するため、グローバルなミューテートを使い再検証するためには、`swr/infintie` にある `unstable_serialize` を使う必要があります。
+`useSWRInfinite` は各ページのデータに加え、全てのページデータを特別な形式のキーでキャッシュに保存するため、グローバルなミューテートを使い再検証するためには、`swr/infinite` にある `unstable_serialize` を使う必要があります。
 
 ```jsx
 import { useSWRConfig } from "swr"
@@ -326,7 +326,7 @@ function App() {
     const { mutate } = useSWRConfig()
     mutate(unstable_serialize(getKey))
 }
-````
+```
 
 <Callout emoji="⚠️">
     名前が示す通り、`unstable_serialize` は安定した API ではなく、将来的に変更される可能性があります。

--- a/pages/docs/pagination.ko.mdx
+++ b/pages/docs/pagination.ko.mdx
@@ -316,7 +316,7 @@ const getKey = (pageIndex, previousPageData) => {
 
 ### Global Mutate with `useSWRInfinite`
 
-`useSWRInfinite` stores all page data into the cache with a special cache key along with each page data, so you have to use `unstable_serialize` in `swr/infintie` to revalidate the data with the global mutate.
+`useSWRInfinite` stores all page data into the cache with a special cache key along with each page data, so you have to use `unstable_serialize` in `swr/infinite` to revalidate the data with the global mutate.
 
 ```jsx
 import { useSWRConfig } from "swr"
@@ -326,7 +326,7 @@ function App() {
     const { mutate } = useSWRConfig()
     mutate(unstable_serialize(getKey))
 }
-````
+```
 
 <Callout emoji="⚠️">
     As the name implies, `unstable_serialize` is not a stable API, so we might change it in the future.

--- a/pages/docs/pagination.ko.mdx
+++ b/pages/docs/pagination.ko.mdx
@@ -320,7 +320,7 @@ const getKey = (pageIndex, previousPageData) => {
 
 ```jsx
 import { useSWRConfig } from "swr"
-import { unstable_serialize } from "swr/infinte"
+import { unstable_serialize } from "swr/infinite"
 
 function App() {
     const { mutate } = useSWRConfig()

--- a/pages/docs/pagination.pt-BR.mdx
+++ b/pages/docs/pagination.pt-BR.mdx
@@ -314,7 +314,7 @@ const getKey = (pageIndex, previousPageData) => {
 
 ### Global Mutate with `useSWRInfinite`
 
-`useSWRInfinite` caches all page data with a special cache key along with each page data. you have to use `unstable_serialize` in `swr/infintie` to revalidate the data with the global mutate.
+`useSWRInfinite` caches all page data with a special cache key along with each page data. you have to use `unstable_serialize` in `swr/infinite` to revalidate the data with the global mutate.
 
 ```jsx
 import { useSWRConfig } from "swr"
@@ -324,7 +324,7 @@ function App() {
     const { mutate } = useSWRConfig()
     mutate(unstable_serialize(getKey))
 }
-````
+```
 
 <Callout emoji="⚠️">
     As the name implies, `unstable_serialize` is not a stable API, so we might change it in the future.

--- a/pages/docs/pagination.pt-BR.mdx
+++ b/pages/docs/pagination.pt-BR.mdx
@@ -318,7 +318,7 @@ const getKey = (pageIndex, previousPageData) => {
 
 ```jsx
 import { useSWRConfig } from "swr"
-import { unstable_serialize } from "swr/infinte"
+import { unstable_serialize } from "swr/infinite"
 
 function App() {
     const { mutate } = useSWRConfig()

--- a/pages/docs/pagination.ru.mdx
+++ b/pages/docs/pagination.ru.mdx
@@ -316,7 +316,7 @@ const getKey = (pageIndex, previousPageData) => {
 
 ### Global Mutate with `useSWRInfinite`
 
-`useSWRInfinite` stores all page data into the cache with a special cache key along with each page data, so you have to use `unstable_serialize` in `swr/infintie` to revalidate the data with the global mutate.
+`useSWRInfinite` stores all page data into the cache with a special cache key along with each page data, so you have to use `unstable_serialize` in `swr/infinite` to revalidate the data with the global mutate.
 
 ```jsx
 import { useSWRConfig } from "swr"
@@ -326,7 +326,7 @@ function App() {
     const { mutate } = useSWRConfig()
     mutate(unstable_serialize(getKey))
 }
-````
+```
 
 <Callout emoji="⚠️">
     As the name implies, `unstable_serialize` is not a stable API, so we might change it in the future.

--- a/pages/docs/pagination.ru.mdx
+++ b/pages/docs/pagination.ru.mdx
@@ -320,7 +320,7 @@ const getKey = (pageIndex, previousPageData) => {
 
 ```jsx
 import { useSWRConfig } from "swr"
-import { unstable_serialize } from "swr/infinte"
+import { unstable_serialize } from "swr/infinite"
 
 function App() {
     const { mutate } = useSWRConfig()

--- a/pages/docs/pagination.zh-CN.mdx
+++ b/pages/docs/pagination.zh-CN.mdx
@@ -309,7 +309,7 @@ const getKey = (pageIndex, previousPageData) => {
 
 ```jsx
 import { useSWRConfig } from "swr"
-import { unstable_serialize } from "swr/infinte"
+import { unstable_serialize } from "swr/infinite"
 
 function App() {
     const { mutate } = useSWRConfig()

--- a/pages/docs/pagination.zh-CN.mdx
+++ b/pages/docs/pagination.zh-CN.mdx
@@ -305,7 +305,7 @@ const getKey = (pageIndex, previousPageData) => {
 
 ### Global Mutate with `useSWRInfinite`
 
-`useSWRInfinite` stores all page data into the cache with a special cache key along with each page data, so you have to use `unstable_serialize` in `swr/infintie` to revalidate the data with the global mutate.
+`useSWRInfinite` stores all page data into the cache with a special cache key along with each page data, so you have to use `unstable_serialize` in `swr/infinite` to revalidate the data with the global mutate.
 
 ```jsx
 import { useSWRConfig } from "swr"
@@ -315,7 +315,7 @@ function App() {
     const { mutate } = useSWRConfig()
     mutate(unstable_serialize(getKey))
 }
-````
+```
 
 <Callout emoji="⚠️">
     As the name implies, `unstable_serialize` is not a stable API, so we might change it in the future.


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

![image](https://user-images.githubusercontent.com/35240142/217491150-bc561695-c74c-45c7-8c3b-2fcb0c8af6fe.png)

- fix typo in example code
  - please check this at https://swr.vercel.app/docs/pagination#global-mutate-with-useswrinfinite
  - and all of docs using this example code with typo

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates