### PR TITLE
fix: Replace `/blog/swr-v1` with `/blog` on index pages

### DIFF
--- a/pages/index.en-US.mdx
+++ b/pages/index.en-US.mdx
@@ -11,7 +11,6 @@ import { Bleed } from 'nextra-theme-docs'
 }
 {<h1 className="text-center text-4xl tracking-tighter font-extrabold md:text-5xl mt-8">SWR</h1>}
 
-
 <Bleed><Features/></Bleed>
 
 The name “SWR” is derived from `stale-while-revalidate`, a HTTP cache invalidation strategy popularized by [HTTP RFC 5861](https://tools.ietf.org/html/rfc5861).
@@ -23,7 +22,7 @@ SWR is a strategy to first return the data from cache (stale), then send the fet
 </Callout>
 
 <div className="mt-16 mb-20 text-center">
-  [Get Started](/docs/getting-started) · [Examples](/examples/basic) · [Blog](/blog/swr-v1) · [GitHub Repository](https://github.com/vercel/swr)
+  [Get Started](/docs/getting-started) · [Examples](/examples/basic) · [Blog](/blog) · [GitHub Repository](https://github.com/vercel/swr)
 </div>
 
 ## Overview

--- a/pages/index.es-ES.mdx
+++ b/pages/index.es-ES.mdx
@@ -24,7 +24,7 @@ SWR es una estrategia para devolver primero los datos en caché (obsoletos), lue
 </Callout>
 
 <div className="mt-16 mb-20 text-center">
-  [Get Started](/docs/getting-started) · [Examples](/examples/basic) · [Blog](/blog/swr-v1) · [GitHub Repository](https://github.com/vercel/swr)
+  [Get Started](/docs/getting-started) · [Examples](/examples/basic) · [Blog](/blog) · [GitHub Repository](https://github.com/vercel/swr)
 </div>
 
 ## Resumen

--- a/pages/index.ja.mdx
+++ b/pages/index.ja.mdx
@@ -24,7 +24,7 @@ SWR は、まずキャッシュからデータを返し（stale）、次にフ�
 </Callout>
 
 <div className="mt-16 mb-20 text-center">
-  [はじめに](/docs/getting-started) · [例題](/examples/basic) · [ブログ](/blog/swr-v1) · [GitHub リポジトリ](https://github.com/vercel/swr)
+  [はじめに](/docs/getting-started) · [例題](/examples/basic) · [ブログ](/blog) · [GitHub リポジトリ](https://github.com/vercel/swr)
 </div>
 
 ## 概要

--- a/pages/index.ko.mdx
+++ b/pages/index.ko.mdx
@@ -22,7 +22,7 @@ SWR은 먼저 캐시(스태일)로부터 데이터를 반환한 후, fetch 요�
 </Callout>
 
 <div className="mt-16 mb-20 text-center">
-  [시작하기](/docs/getting-started) · [예시](/examples/basic) · [블로그](/blog/swr-v1) · [GitHub 리포지터리](https://github.com/vercel/swr)
+  [시작하기](/docs/getting-started) · [예시](/examples/basic) · [블로그](/blog) · [GitHub 리포지터리](https://github.com/vercel/swr)
 </div>
 
 ## 개요

--- a/pages/index.pt-BR.mdx
+++ b/pages/index.pt-BR.mdx
@@ -22,7 +22,7 @@ SWR é a estratégia de primeiro retornar os dados do cache (stale), depois envi
 </Callout>
 
 <div className="mt-16 mb-20 text-center">
-  [Comece a Usar](/docs/getting-started) · [Exemplos](/examples/basic) · [Blog](/blog/swr-v1) · [Repositório do GitHub](https://github.com/vercel/swr)
+  [Comece a Usar](/docs/getting-started) · [Exemplos](/examples/basic) · [Blog](/blog) · [Repositório do GitHub](https://github.com/vercel/swr)
 </div>
 
 ## Visão geral

--- a/pages/index.ru.mdx
+++ b/pages/index.ru.mdx
@@ -23,7 +23,7 @@ import { Bleed } from 'nextra-theme-docs'
 </Callout>
 
 <div className="mt-16 mb-20 text-center">
-  [Начать работу](/docs/getting-started) · [Примеры](/examples/basic) · [Блог](/blog/swr-v1) · [Репозиторий GitHub](https://github.com/vercel/swr)
+  [Начать работу](/docs/getting-started) · [Примеры](/examples/basic) · [Блог](/blog) · [Репозиторий GitHub](https://github.com/vercel/swr)
 </div>
 
 ## Обзор

--- a/pages/index.zh-CN.mdx
+++ b/pages/index.zh-CN.mdx
@@ -23,7 +23,7 @@ import { Bleed } from 'nextra-theme-docs'
 </Callout>
 
 <div className="mt-16 mb-20 text-center">
-  [入门](/docs/getting-started) · [示例](/examples/basic) · [博客](/blog/swr-v1) · [GitHub 仓库](https://github.com/vercel/swr)
+  [入门](/docs/getting-started) · [示例](/examples/basic) · [博客](/blog) · [GitHub 仓库](https://github.com/vercel/swr)
 </div>
 
 ## 概览


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description
The index page contains a link for Blog.  When clicking on the link it directs the user to [Announcing SWR 1.0](https://swr.vercel.app/blog/swr-v1), the first blog post.  As there are now two blog posts on the site, I changed the Blog link on the index page to direct the user to [SWR Blog](https://swr.vercel.app/blog) instead.  This allows the user see all of the blog posts instead of giving the false impression that there is only one.

### Changes
* Replace `/blog/swr-v1` with `/blog` in all `pages/index*` mdx files
* Removed empty new line in `index.en-US.mdx`

### Screenshots
Current - Hovering Blog shows link to `localhost:3000/blog/swr-v1` - (Highlighted with red square)
![Screenshot 2023-02-23 at 10 48 38 AM](https://user-images.githubusercontent.com/14244920/220963807-371d82b4-fbf2-4fe4-9b2e-3c7d5d9dc378.png)

Update - Hovering Blog shows link to `localhost:3000/blog` - (Highlighted with red square)
![Screenshot 2023-02-23 at 10 48 14 AM](https://user-images.githubusercontent.com/14244920/220963780-34ffb665-a691-4097-8505-4fb3c16bc143.png)

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


