### PR TITLE
docs: fix translation omissions

### DIFF
--- a/pages/docs/api.ja.mdx
+++ b/pages/docs/api.ja.mdx
@@ -20,7 +20,7 @@ const { data, error, isLoading, isValidating, mutate } = useSWR(key, fetcher, op
 - `isValidating`: リクエストまたは再検証の読み込みがある場合
 - `mutate(data?, options?)`: キャッシュされたデータを更新する関数 [（ 詳細 ）](/docs/mutation)
 
-More information can be found [here](/docs/advanced/understanding).
+詳細は[こちら](/docs/advanced/understanding)をご覧ください。
 
 ## オプション
 


### PR DESCRIPTION
### Description

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates

A translation omission in the Japanese document has been corrected.
