### PR TITLE
docs: fix typo

### DIFF
--- a/pages/docs/global-configuration.ja.mdx
+++ b/pages/docs/global-configuration.ja.mdx
@@ -111,7 +111,7 @@ function Page() {
 
 ### キャッシュプロバイダー
 
-紹介されているすべてのオプションに加えて、 `SWRConfig` または `provider` 関数も受け入れます。詳細は[キャッシュ](/docs/advanced/cache)セクションを参照してください。
+紹介されているすべてのオプションに加えて、 `SWRConfig` は `provider` 関数も受け入れます。詳細は[キャッシュ](/docs/advanced/cache)セクションを参照してください。
 
 ```jsx
 <SWRConfig value={{ provider: () => new Map() }}>


### PR DESCRIPTION
### Description

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates

A typo in the Japanese documentation has been corrected.
