### PR TITLE
Update documentation for the Bound Mutate example

### DIFF
--- a/pages/docs/mutation.en-US.mdx
+++ b/pages/docs/mutation.en-US.mdx
@@ -53,10 +53,12 @@ function Profile () {
       <button onClick={async () => {
         const newName = data.name.toUpperCase()
         // send a request to the API to update the data
-        await requestUpdateUsername(newName)
         // update the local data immediately and revalidate (refetch)
         // NOTE: key is not required when using useSWR's mutate as it's pre-bound
-        mutate({ ...data, name: newName })
+        mutate(requestUpdateUsername(newName), {
+          optimisticData: { ...data, name: newName },
+          revalidate: true,
+        })
       }}>Uppercase my name!</button>
     </div>
   )


### PR DESCRIPTION
A bound mutate method requires a KeyedMutator which is either Data or a Promise to return Data.

<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

I was trying to follow the example in the Bound mutator section of the documentation and came across this example which is wrong. A bound mutator requires a KeyedMutator 

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


