### PR TITLE
Minor typo fixes in typescript Docs

### DIFF
--- a/pages/docs/typescript.en-US.mdx
+++ b/pages/docs/typescript.en-US.mdx
@@ -34,7 +34,7 @@ const { data } = useSWR(uid, fetcher)
 // `data` will be `User | undefined`.
 ```
 
-By default, [the error thrown](/docs/error-handling) inside the `fetcher` function has type `any`. The type can also explicitly specified.
+By default, [the error thrown](/docs/error-handling) inside the `fetcher` function has type `any`. The type can also be explicitly specified.
 
 ```typescript
 const { data, error } = useSWR<User, Error>(uid, fetcher);
@@ -59,7 +59,7 @@ const { data } = useSWRInfinite(getKey, fetcher)
 
 ### useSWRSubscription
 
-* Inline subscribe function and mamually specify the type of `next`  using `SWRSubscriptionOptions`.
+* Inline subscribe function and manually specify the type of `next`  using `SWRSubscriptionOptions`.
 
 ```tsx
 import useSWRSubscription from 'swr/subscription'


### PR DESCRIPTION
### Description

Updated two minor typo errors in the English docs for typescript.

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


