### PR TITLE
docs: fixed misspell in example section

### DIFF
--- a/pages/docs/getting-started.pt-BR.mdx
+++ b/pages/docs/getting-started.pt-BR.mdx
@@ -35,7 +35,7 @@ const fetcher = (...args) => fetch(...args).then(res => res.json())
 
 <Callout emoji="💡">
     Se você quer usar APIs GraphQL ou outras bibliotecas como Axios, você pode criar sua própria função fetcher.
-    Veja maias exemplos clicando <Link href="/docs/data-fetching">aqui</Link>.
+    Veja mais exemplos clicando <Link href="/docs/data-fetching">aqui</Link>.
 </Callout>
 
 Então você pode importar `useSWR` e começar a usá-lo em qualquer componente funcional:


### PR DESCRIPTION
- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates

it was "veja maias exemplos", and the correct is "veja mais exemplos"
