### PR TITLE
docs: Update useSWR return value descriptions

### DIFF
--- a/pages/index.en-US.mdx
+++ b/pages/index.en-US.mdx
@@ -42,7 +42,7 @@ function Profile() {
 In this example, the `useSWR` hook accepts a `key` string and a `fetcher` function. `key` is a unique identifier of the data (normally the API URL)
 and will be passed to `fetcher`. `fetcher` can be any asynchronous function which returns the data, you can use the native fetch or tools like Axios.
 
-The hook returns 2 values: `data`, `isLoading` and `error`, based on the status of the request.
+The hook returns 3 values: `data`, `isLoading` and `error`, based on the status of the request.
 
 ## Features [#features]
 

--- a/pages/index.en-US.mdx
+++ b/pages/index.en-US.mdx
@@ -42,7 +42,7 @@ function Profile() {
 In this example, the `useSWR` hook accepts a `key` string and a `fetcher` function. `key` is a unique identifier of the data (normally the API URL)
 and will be passed to `fetcher`. `fetcher` can be any asynchronous function which returns the data, you can use the native fetch or tools like Axios.
 
-The hook returns 2 values: `data` and `error`, based on the status of the request.
+The hook returns 2 values: `data`, `isLoading` and `error`, based on the status of the request.
 
 ## Features [#features]
 

--- a/pages/index.ko.mdx
+++ b/pages/index.ko.mdx
@@ -42,7 +42,7 @@ function Profile() {
 이 예시에서, `useSWR` hook은 `key` 문자열과 `fetcher` 함수를 받습니다. `key`는 데이터의 고유한 식별자이며(일반적으로 API URL)
 `fetcher`로 전달될 것입니다. `fetcher`는 데이터를 반환하는 어떠한 비동기 함수도 될 수 있습니다. 네이티브 fetch 또는 Axios와 같은 도구를 사용할 수 있습니다.
 
-hook은 두 개의 값을 반환합니다: 요청의 상태에 기반한 `data`와 `error`.
+hook은 두 개의 값을 반환합니다: 요청의 상태에 기반한 `data`, `isLoading` 그리고 `error`.
 
 ## 기능 [#features]
 

--- a/pages/index.ko.mdx
+++ b/pages/index.ko.mdx
@@ -42,7 +42,7 @@ function Profile() {
 이 예시에서, `useSWR` hook은 `key` 문자열과 `fetcher` 함수를 받습니다. `key`는 데이터의 고유한 식별자이며(일반적으로 API URL)
 `fetcher`로 전달될 것입니다. `fetcher`는 데이터를 반환하는 어떠한 비동기 함수도 될 수 있습니다. 네이티브 fetch 또는 Axios와 같은 도구를 사용할 수 있습니다.
 
-hook은 두 개의 값을 반환합니다: 요청의 상태에 기반한 `data`, `isLoading` 그리고 `error`.
+hook은 세 개의 값을 반환합니다: 요청의 상태에 기반한 `data`, `isLoading` 그리고 `error`.
 
 ## 기능 [#features]
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)




🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

I Update return value description in [Index page](https://swr.vercel.app/)

I think this example using `data`, `isLoading` and `error`. 
However, `isLoading` is missing from the description.

So I add isLoading in en-US and ko.

### Questions

As far as I know, the `useSWR` has other return values except for `data`, `isLoading`, and `error`, 
but the description says that **only 2 values are returned**. 

How about hanging the `read more link` for the other return values??

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


