### PR TITLE
chore: Update useless className using gap-2

### DIFF
--- a/pages/index.en-US.mdx
+++ b/pages/index.en-US.mdx
@@ -72,10 +72,10 @@ And a lot [more](/docs/getting-started).
 
 ## Community [#community]
 
-<p className="flex h-6 mt-4">
-  <img alt="stars" src="https://badgen.net/github/stars/vercel/swr" className="inline-block mr-2"/>
-  <img alt="downloads" src="https://badgen.net/npm/dt/swr" className="inline-block mr-2"/>
-  <img alt="license" src="https://badgen.net/npm/license/swr" className="inline-block mr-2"/>
+<p className="flex h-6 mt-4 gap-2">
+  <img alt="stars" src="https://badgen.net/github/stars/vercel/swr" />
+  <img alt="downloads" src="https://badgen.net/npm/dt/swr" />
+  <img alt="license" src="https://badgen.net/npm/license/swr" />
 </p>
 
 SWR is created by the same team behind [Next.js](https://nextjs.org), the React framework.

--- a/pages/index.es-ES.mdx
+++ b/pages/index.es-ES.mdx
@@ -74,10 +74,10 @@ And lot [more](/docs/getting-started).
 
 ## Comunidad [#community]
 
-<p className="flex h-6 mt-4">
-  <img alt="stars" src="https://badgen.net/github/stars/vercel/swr" className="inline-block mr-2"/>
-  <img alt="downloads" src="https://badgen.net/npm/dt/swr" className="inline-block mr-2"/>
-  <img alt="license" src="https://badgen.net/npm/license/swr" className="inline-block mr-2"/>
+<p className="flex h-6 mt-4 gap-2">
+  <img alt="stars" src="https://badgen.net/github/stars/vercel/swr" />
+  <img alt="downloads" src="https://badgen.net/npm/dt/swr" />
+  <img alt="license" src="https://badgen.net/npm/license/swr" />
 </p>
 
 SWR es creado por el mismo equipo que esta detrás de [Next.js](https://nextjs.org), el framework de React.

--- a/pages/index.fr-FR.mdx
+++ b/pages/index.fr-FR.mdx
@@ -72,10 +72,10 @@ Et bien [plus](/docs/getting-started).
 
 ## Communauté [#community]
 
-<p className="flex h-6 mt-4">
-  <img alt="stars" src="https://badgen.net/github/stars/vercel/swr" className="inline-block mr-2"/>
-  <img alt="downloads" src="https://badgen.net/npm/dt/swr" className="inline-block mr-2"/>
-  <img alt="license" src="https://badgen.net/npm/license/swr" className="inline-block mr-2"/>
+<p className="flex h-6 mt-4 gap-2">
+  <img alt="stars" src="https://badgen.net/github/stars/vercel/swr" />
+  <img alt="downloads" src="https://badgen.net/npm/dt/swr" />
+  <img alt="license" src="https://badgen.net/npm/license/swr" />
 </p>
 
 SWR est créé par l'équipe derrière [Next.js](https://nextjs.org), le framework React.

--- a/pages/index.ja.mdx
+++ b/pages/index.ja.mdx
@@ -74,10 +74,10 @@ And lot [more](/docs/getting-started).
 
 ## コミュニティ [#community]
 
-<p className="flex h-6 mt-4">
-  <img alt="stars" src="https://badgen.net/github/stars/vercel/swr" className="inline-block mr-2"/>
-  <img alt="downloads" src="https://badgen.net/npm/dt/swr" className="inline-block mr-2"/>
-  <img alt="license" src="https://badgen.net/npm/license/swr" className="inline-block mr-2"/>
+<p className="flex h-6 mt-4 gap-2">
+  <img alt="stars" src="https://badgen.net/github/stars/vercel/swr" />
+  <img alt="downloads" src="https://badgen.net/npm/dt/swr" />
+  <img alt="license" src="https://badgen.net/npm/license/swr" />
 </p>
 
 SWR は、React フレームワークである [Next.js](https://nextjs.org) と同じチームによって作られています。

--- a/pages/index.ko.mdx
+++ b/pages/index.ko.mdx
@@ -72,10 +72,10 @@ SWR은 더 나은 경험을 구축할 수 있도록 속도, 정확성, 안정성
 
 ## 커뮤니티 [#community]
 
-<p className="flex h-6 mt-4">
-  <img alt="stars" src="https://badgen.net/github/stars/vercel/swr" className="inline-block mr-2"/>
-  <img alt="downloads" src="https://badgen.net/npm/dt/swr" className="inline-block mr-2"/>
-  <img alt="license" src="https://badgen.net/npm/license/swr" className="inline-block mr-2"/>
+<p className="flex h-6 mt-4 gap-2">
+  <img alt="stars" src="https://badgen.net/github/stars/vercel/swr" />
+  <img alt="downloads" src="https://badgen.net/npm/dt/swr" />
+  <img alt="license" src="https://badgen.net/npm/license/swr" />
 </p>
 
 SWR은 React 프레임워크인 [Next.js](https://nextjs.org)를 만든 동일한 팀이 만들었습니다.

--- a/pages/index.pt-BR.mdx
+++ b/pages/index.pt-BR.mdx
@@ -72,10 +72,10 @@ E muito [mais](/docs/getting-started).
 
 ## Comunidade [#community]
 
-<p className="flex h-6 mt-4">
-  <img alt="stars" src="https://badgen.net/github/stars/vercel/swr" className="inline-block mr-2"/>
-  <img alt="downloads" src="https://badgen.net/npm/dt/swr" className="inline-block mr-2"/>
-  <img alt="license" src="https://badgen.net/npm/license/swr" className="inline-block mr-2"/>
+<p className="flex h-6 mt-4 gap-2">
+  <img alt="stars" src="https://badgen.net/github/stars/vercel/swr" />
+  <img alt="downloads" src="https://badgen.net/npm/dt/swr" />
+  <img alt="license" src="https://badgen.net/npm/license/swr" />
 </p>
 
 SWR é criado pelo mesmo time por trás do [Next.js](https://nextjs.org), o framework React. Siga [@vercel](https://twitter.com/vercel) no Twitter para atualizações futuras do projeto.

--- a/pages/index.ru.mdx
+++ b/pages/index.ru.mdx
@@ -73,10 +73,10 @@ SWR охватывает все аспекты скорости, правиль�
 
 ## Сообщество [#community]
 
-<p className="flex h-6 mt-4">
-  <img alt="звёзды" src="https://badgen.net/github/stars/vercel/swr" className="inline-block mr-2"/>
-  <img alt="загрузки" src="https://badgen.net/npm/dt/swr" className="inline-block mr-2"/>
-  <img alt="лицензия" src="https://badgen.net/npm/license/swr" className="inline-block mr-2"/>
+<p className="flex h-6 mt-4 gap-2">
+  <img alt="звёзды" src="https://badgen.net/github/stars/vercel/swr" />
+  <img alt="загрузки" src="https://badgen.net/npm/dt/swr" />
+  <img alt="лицензия" src="https://badgen.net/npm/license/swr" />
 </p>
 
 SWR создана той же командой, что стоит за React фреймворком [Next.js](https://nextjs.org).

--- a/pages/index.zh-CN.mdx
+++ b/pages/index.zh-CN.mdx
@@ -72,22 +72,10 @@ SWR 涵盖了性能，正确性和稳定性的各个方面，以帮你建立更�
 
 ## 社区 [#community]
 
-<p className="flex h-6 mt-4">
-  <img
-    alt="stars"
-    src="https://badgen.net/github/stars/vercel/swr"
-    className="inline-block mr-2"
-  />
-  <img
-    alt="downloads"
-    src="https://badgen.net/npm/dt/swr"
-    className="inline-block mr-2"
-  />
-  <img
-    alt="license"
-    src="https://badgen.net/npm/license/swr"
-    className="inline-block mr-2"
-  />
+<p className="flex h-6 mt-4 gap-2">
+  <img alt="stars" src="https://badgen.net/github/stars/vercel/swr" />
+  <img alt="downloads" src="https://badgen.net/npm/dt/swr" />
+  <img alt="license" src="https://badgen.net/npm/license/swr" />
 </p>
 
 SWR 由 [Next.js](https://nextjs.org)（React 框架）背后的同一团队创建。


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

<!-- What're you changing? -->

I think this can be minor changes... but I think this is useless classNames solved by using `gap-2` to parent `p` tag.

- [ ] Adding new page
- [ ] Updating existing documentation
- [x] Other updates


