### PR TITLE
Remove unnecessary warning to using `Suspense`

### DIFF
--- a/pages/docs/suspense.en-US.mdx
+++ b/pages/docs/suspense.en-US.mdx
@@ -2,10 +2,6 @@ import { Callout } from 'nextra-theme-docs'
 
 # Suspense
 
-<Callout emoji="🚨" type="error">
-  React still <strong>doesn't recommend</strong> using `Suspense` in data frameworks like SWR (<a href="https://reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">More information</a>). These APIs may change in the future as the results of our research.
-</Callout>
-
 You can enable the `suspense` option to use SWR with React Suspense:
 
 ```jsx

--- a/pages/docs/suspense.es-ES.mdx
+++ b/pages/docs/suspense.es-ES.mdx
@@ -2,10 +2,6 @@ import { Callout } from 'nextra-theme-docs'
 
 # Suspense
 
-<Callout emoji="🚨" type="error">
-  React still <strong>doesn't recommend</strong> using `Suspense` in data frameworks like SWR (<a href="https://reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">More information</a>). These APIs may change in the future as the results of our research.
-</Callout>
-
 Puede activar la opción `suspense` para utilizar SWR con React Suspense:
 
 ```jsx

--- a/pages/docs/suspense.fr-FR.mdx
+++ b/pages/docs/suspense.fr-FR.mdx
@@ -2,10 +2,6 @@ import { Callout } from 'nextra-theme-docs'
 
 # Suspense
 
-<Callout emoji="🚨" type="error">
-  React <strong>ne recommande toujours pas</strong> d'utiliser `Suspense` dans les frameworks de données comme SWR (<a href="https://reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">Plus d'informations</a>). Ces API peuvent changer à l'avenir en fonction des résultats de nos recherches.
-</Callout>
-
 Vous pouvez activer l'option `suspense` pour utiliser SWR avec React Suspense :
 
 ```jsx

--- a/pages/docs/suspense.ja.mdx
+++ b/pages/docs/suspense.ja.mdx
@@ -2,10 +2,6 @@ import { Callout } from 'nextra-theme-docs'
 
 # サスペンス
 
-<Callout emoji="🚨" type="error">
-  React はまだサスペンスをデータ取得フレームワークである SWR などで使うことを <strong>推奨していません</strong> (<a href="https://reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">詳細</a>)。 これらの API は将来的に私たちの調査により変更される可能性があります。
-</Callout>
-
 React サスペンスで SWR を使用するには、 `suspense` オプションを有効にします。
 
 ```jsx

--- a/pages/docs/suspense.ko.mdx
+++ b/pages/docs/suspense.ko.mdx
@@ -2,10 +2,6 @@ import { Callout } from 'nextra-theme-docs'
 
 # 서스펜스
 
-<Callout emoji="🚨" type="error">
-  리액트는 여전히 SWR(<a href="https://reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">추가 정보</a>) 과 같은 데이터 프레임워크에서 서스펜스를 사용하는 것을 권장하지 않습니다. 이러한 API는 향후 연구 결과에 따라 변경될 수 있습니다.
-</Callout>
-
 React 서스펜스를 SWR과 함께 사용하려면 `suspense` 옵션을 활성화하세요.
 
 ```jsx

--- a/pages/docs/suspense.pt-BR.mdx
+++ b/pages/docs/suspense.pt-BR.mdx
@@ -2,10 +2,6 @@ import { Callout } from 'nextra-theme-docs'
 
 # Suspense
 
-<Callout emoji="🚨" type="error">
-  O React <strong>não recomenda</strong> usar `Suspense` em frameworks de dados como o SWR (<a href="https://reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">Mais informações</a>). Essas APIs podem mudar no futuro como resultados da nossa pesquisa.
-</Callout>
-
 Você pode habilitar a opção `suspense` para usar SWR com React Suspense:
 
 ```jsx

--- a/pages/docs/suspense.ru.mdx
+++ b/pages/docs/suspense.ru.mdx
@@ -2,10 +2,6 @@ import { Callout } from 'nextra-theme-docs'
 
 # Задержка (Suspense)
 
-<Callout emoji="🚨" type="error">
-  React по-прежнему <strong>не рекомендует</strong> использовать Suspense в таких фреймворках, как SWR. (<a href="https://ru.reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">Дополнительная информация</a>). По результатам нашего исследования эти API могут измениться в будущем.
-</Callout>
-
 Вы можете включить опцию `suspense`, чтобы использовать SWR с React Suspense:
 
 ```jsx

--- a/pages/docs/suspense.zh-CN.mdx
+++ b/pages/docs/suspense.zh-CN.mdx
@@ -2,10 +2,6 @@ import { Callout } from 'nextra-theme-docs'
 
 # Suspense
 
-<Callout emoji="🚨" type="error">
-  React 仍然不建议在 SWR 这样的数据框架中使用 `Suspense` (<a href="https://reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">更多信息</a>)。根据我们的调查结果，这些 API 将来可能会发生变化。
-</Callout>
-
 你可以启用 `suspense` 选项，从而让 SWR 和 React Suspense 一起使用：
 
 ```jsx


### PR DESCRIPTION
### Description

I removed warning to using `Suspense` below:

```
React still doesn't recommend using Suspense in data frameworks like SWR
```

Because the `React` documentation currently says that `Suspense` is activate for Suspense-enabled data sources, below:

```
Only Suspense-enabled data sources will activate the Suspense component
```

Ref: https://react.dev/reference/react/Suspense

The above content was added by [this PR](https://github.com/reactjs/react.dev/pull/5308). It's newer than the [blog](https://react.dev/blog/2022/03/29/react-v18#suspense-in-data-frameworks) referenced in the text removed by this PR is.

Since `SWR` is included in Suspense-enabled data sources, I believe this warning is no longer necessary.

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


