### PR TITLE
Use aspect-ratio for height on Examples

### DIFF
--- a/pages/examples/auth.en-US.mdx
+++ b/pages/examples/auth.en-US.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.en-US.mdx
+++ b/pages/examples/auth.en-US.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.es-ES.mdx
+++ b/pages/examples/auth.es-ES.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.es-ES.mdx
+++ b/pages/examples/auth.es-ES.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.fr-FR.mdx
+++ b/pages/examples/auth.fr-FR.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.fr-FR.mdx
+++ b/pages/examples/auth.fr-FR.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.ja.mdx
+++ b/pages/examples/auth.ja.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.ja.mdx
+++ b/pages/examples/auth.ja.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.ko.mdx
+++ b/pages/examples/auth.ko.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.ko.mdx
+++ b/pages/examples/auth.ko.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.pt-BR.mdx
+++ b/pages/examples/auth.pt-BR.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.pt-BR.mdx
+++ b/pages/examples/auth.pt-BR.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.ru.mdx
+++ b/pages/examples/auth.ru.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.ru.mdx
+++ b/pages/examples/auth.ru.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.zh-CN.mdx
+++ b/pages/examples/auth.zh-CN.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/auth.zh-CN.mdx
+++ b/pages/examples/auth.zh-CN.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-auth-vl653w?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.en-US.mdx
+++ b/pages/examples/basic.en-US.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.en-US.mdx
+++ b/pages/examples/basic.en-US.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.es-ES.mdx
+++ b/pages/examples/basic.es-ES.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.es-ES.mdx
+++ b/pages/examples/basic.es-ES.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.fr-FR.mdx
+++ b/pages/examples/basic.fr-FR.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.fr-FR.mdx
+++ b/pages/examples/basic.fr-FR.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.ja.mdx
+++ b/pages/examples/basic.ja.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.ja.mdx
+++ b/pages/examples/basic.ja.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.ko.mdx
+++ b/pages/examples/basic.ko.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.ko.mdx
+++ b/pages/examples/basic.ko.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.pt-BR.mdx
+++ b/pages/examples/basic.pt-BR.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.pt-BR.mdx
+++ b/pages/examples/basic.pt-BR.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.ru.mdx
+++ b/pages/examples/basic.ru.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.ru.mdx
+++ b/pages/examples/basic.ru.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.zh-CN.mdx
+++ b/pages/examples/basic.zh-CN.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/basic.zh-CN.mdx
+++ b/pages/examples/basic.zh-CN.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-2s1itw?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.en-US.mdx
+++ b/pages/examples/error-handling.en-US.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.en-US.mdx
+++ b/pages/examples/error-handling.en-US.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.es-ES.mdx
+++ b/pages/examples/error-handling.es-ES.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.es-ES.mdx
+++ b/pages/examples/error-handling.es-ES.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.fr-FR.mdx
+++ b/pages/examples/error-handling.fr-FR.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.fr-FR.mdx
+++ b/pages/examples/error-handling.fr-FR.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.ja.mdx
+++ b/pages/examples/error-handling.ja.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.ja.mdx
+++ b/pages/examples/error-handling.ja.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.ko.mdx
+++ b/pages/examples/error-handling.ko.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.ko.mdx
+++ b/pages/examples/error-handling.ko.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.pt-BR.mdx
+++ b/pages/examples/error-handling.pt-BR.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.pt-BR.mdx
+++ b/pages/examples/error-handling.pt-BR.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.ru.mdx
+++ b/pages/examples/error-handling.ru.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.ru.mdx
+++ b/pages/examples/error-handling.ru.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.zh-CN.mdx
+++ b/pages/examples/error-handling.zh-CN.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/error-handling.zh-CN.mdx
+++ b/pages/examples/error-handling.zh-CN.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-states-7njdkp?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.en-US.mdx
+++ b/pages/examples/infinite-loading.en-US.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.en-US.mdx
+++ b/pages/examples/infinite-loading.en-US.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.es-ES.mdx
+++ b/pages/examples/infinite-loading.es-ES.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.es-ES.mdx
+++ b/pages/examples/infinite-loading.es-ES.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.fr-FR.mdx
+++ b/pages/examples/infinite-loading.fr-FR.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.fr-FR.mdx
+++ b/pages/examples/infinite-loading.fr-FR.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.ja.mdx
+++ b/pages/examples/infinite-loading.ja.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.ja.mdx
+++ b/pages/examples/infinite-loading.ja.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.ko.mdx
+++ b/pages/examples/infinite-loading.ko.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.ko.mdx
+++ b/pages/examples/infinite-loading.ko.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.pt-BR.mdx
+++ b/pages/examples/infinite-loading.pt-BR.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.pt-BR.mdx
+++ b/pages/examples/infinite-loading.pt-BR.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.ru.mdx
+++ b/pages/examples/infinite-loading.ru.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.ru.mdx
+++ b/pages/examples/infinite-loading.ru.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.zh-CN.mdx
+++ b/pages/examples/infinite-loading.zh-CN.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/infinite-loading.zh-CN.mdx
+++ b/pages/examples/infinite-loading.zh-CN.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-infinite-fxn6ln?file=/src/App.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.en-US.mdx
+++ b/pages/examples/optimistic-ui.en-US.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-gry7m0?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.en-US.mdx
+++ b/pages/examples/optimistic-ui.en-US.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-gry7m0?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.es-ES.mdx
+++ b/pages/examples/optimistic-ui.es-ES.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-gry7m0?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.es-ES.mdx
+++ b/pages/examples/optimistic-ui.es-ES.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-gry7m0?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.fr-FR.mdx
+++ b/pages/examples/optimistic-ui.fr-FR.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-gry7m0?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.fr-FR.mdx
+++ b/pages/examples/optimistic-ui.fr-FR.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-gry7m0?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.ja.mdx
+++ b/pages/examples/optimistic-ui.ja.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-gry7m0?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.ja.mdx
+++ b/pages/examples/optimistic-ui.ja.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-gry7m0?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.ko.mdx
+++ b/pages/examples/optimistic-ui.ko.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-k5hps?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.ko.mdx
+++ b/pages/examples/optimistic-ui.ko.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-k5hps?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.pt-BR.mdx
+++ b/pages/examples/optimistic-ui.pt-BR.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-gry7m0?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.pt-BR.mdx
+++ b/pages/examples/optimistic-ui.pt-BR.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-gry7m0?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.ru.mdx
+++ b/pages/examples/optimistic-ui.ru.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-gry7m0?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.ru.mdx
+++ b/pages/examples/optimistic-ui.ru.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-gry7m0?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.zh-CN.mdx
+++ b/pages/examples/optimistic-ui.zh-CN.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-gry7m0?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/optimistic-ui.zh-CN.mdx
+++ b/pages/examples/optimistic-ui.zh-CN.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-basic-forked-gry7m0?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.en-US.mdx
+++ b/pages/examples/ssr.en-US.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-0huort?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.en-US.mdx
+++ b/pages/examples/ssr.en-US.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-0huort?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.es-ES.mdx
+++ b/pages/examples/ssr.es-ES.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-0huort?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.es-ES.mdx
+++ b/pages/examples/ssr.es-ES.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-0huort?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.fr-FR.mdx
+++ b/pages/examples/ssr.fr-FR.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-0huort?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.fr-FR.mdx
+++ b/pages/examples/ssr.fr-FR.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-0huort?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.ja.mdx
+++ b/pages/examples/ssr.ja.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-0huort?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.ja.mdx
+++ b/pages/examples/ssr.ja.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-0huort?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.ko.mdx
+++ b/pages/examples/ssr.ko.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-j9b2y?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.ko.mdx
+++ b/pages/examples/ssr.ko.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-j9b2y?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.pt-BR.mdx
+++ b/pages/examples/ssr.pt-BR.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-0huort?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.pt-BR.mdx
+++ b/pages/examples/ssr.pt-BR.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-0huort?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.ru.mdx
+++ b/pages/examples/ssr.ru.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-0huort?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.ru.mdx
+++ b/pages/examples/ssr.ru.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-0huort?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.zh-CN.mdx
+++ b/pages/examples/ssr.zh-CN.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-0huort?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/ssr.zh-CN.mdx
+++ b/pages/examples/ssr.zh-CN.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-ssr-0huort?file=/pages/index.js?codemirror=1&fontsize=14&theme=dark&autoresize=1&hidenavigation=1"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.en-US.mdx
+++ b/pages/examples/subscription.en-US.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.en-US.mdx
+++ b/pages/examples/subscription.en-US.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.es-ES.mdx
+++ b/pages/examples/subscription.es-ES.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.es-ES.mdx
+++ b/pages/examples/subscription.es-ES.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.fr-FR.mdx
+++ b/pages/examples/subscription.fr-FR.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.fr-FR.mdx
+++ b/pages/examples/subscription.fr-FR.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.ja.mdx
+++ b/pages/examples/subscription.ja.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.ja.mdx
+++ b/pages/examples/subscription.ja.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.ko.mdx
+++ b/pages/examples/subscription.ko.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.ko.mdx
+++ b/pages/examples/subscription.ko.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.pt-BR.mdx
+++ b/pages/examples/subscription.pt-BR.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.pt-BR.mdx
+++ b/pages/examples/subscription.pt-BR.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.ru.mdx
+++ b/pages/examples/subscription.ru.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.ru.mdx
+++ b/pages/examples/subscription.ru.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.zh-CN.mdx
+++ b/pages/examples/subscription.zh-CN.mdx
@@ -7,7 +7,7 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    height: '100%',
+    aspectRatio: 1,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'

--- a/pages/examples/subscription.zh-CN.mdx
+++ b/pages/examples/subscription.zh-CN.mdx
@@ -7,7 +7,8 @@ full: true
   src="https://codesandbox.io/embed/swr-subscription-example-o0m1pg?fontsize=14&hidenavigation=1&theme=dark"
   style={{
     width: '100%',
-    aspectRatio: 1,
+    aspectRatio: "1 / 2",
+    maxHeight: 900,
     border: 0,
     overflow: 'hidden',
     background: 'rgb(21, 21, 21)'


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

<!-- What're you changing? -->

- [ ] Adding new page
- [ ] Updating existing documentation
- [x] Other updates

On the Examples page, thanks to `height: 100%;`, the content overflows and goes up on the footer.
![image](https://github.com/vercel/swr-site/assets/47110995/4efe45a6-e73b-44d3-bafe-e37c8296bc1d)

A quick fix to it is use `aspect-ratio: 1 / 2` to have a specific height set based by the width, then fixing the overflow issue. Plus, adding a `max-height` of nearly 900px (near of an 1:1 ratio from desktop), this makes responsiveness better on mobile devices.

![image](https://github.com/vercel/swr-site/assets/47110995/3a624f57-f11f-495f-85df-9abb299e437d)

## Resolution

On a half size of an ultrawide display:

Before: 909x842
After: 909x900
