### PR TITLE
fix: typo in portuguese version of Suspense page

### DIFF
--- a/pages/docs/suspense.pt-BR.mdx
+++ b/pages/docs/suspense.pt-BR.mdx
@@ -42,7 +42,7 @@ Mas se um erro ocorreu, você precisa usar um [limite de erro (Error Boundary)](
 ```
 
 <Callout>
-  O modo Suspense suspende a renderização até que os dados estejam prontos, o que singifica que pode causar problemas de waterfall fácilmente. Para evitar isso, você deve fazer prefetch de recursos antes de renderizar. [Mais informações](/docs/prefetching)
+  O modo Suspense suspende a renderização até que os dados estejam prontos, o que significa que pode causar problemas de waterfall facilmente. Para evitar isso, você deve fazer prefetch de recursos antes de renderizar. [Mais informações](/docs/prefetching)
 </Callout>
 
 ### Nota: Com Fetching Condicional [#note-with-conditional-fetching]


### PR DESCRIPTION
### Description

Fix typo in portuguese version of Suspense page.
<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


