### PR TITLE
Update api.en-US.mdx

### DIFF
--- a/pages/docs/api.en-US.mdx
+++ b/pages/docs/api.en-US.mdx
@@ -10,7 +10,7 @@ const { data, error, isLoading, isValidating, mutate } = useSWR(key, fetcher, op
 ## Parameters [#parameters]
 
 - `key`: a unique key string for the request (or a function / array / null) [(details)](/docs/arguments), [(advanced usage)](/docs/conditional-fetching)
-- `fetcher`: (_optional_) a Promise returning function to fetch your data [(details)](/docs/data-fetching)
+- `fetcher`: (_optional_) a Promise-returning function to fetch your data [(details)](/docs/data-fetching)
 - `options`: (_optional_) an object of options for this SWR hook
 
 ## Return Values [#return-values]


### PR DESCRIPTION
Without the hyphen it could mean a `Promise` that returns a function, as opposed to a function that returns a `Promise`.

### Description

<!-- What're you changing? -->

- [ ] Adding new page
- [X] Updating existing documentation
- [ ] Other updates


