### PR TITLE
docs: clarify usage of useSWRMutation with optimisticData

### DIFF
--- a/pages/docs/mutation.en-US.mdx
+++ b/pages/docs/mutation.en-US.mdx
@@ -328,6 +328,7 @@ import useSWRMutation from 'swr/mutation'
 
 function Profile () {
   const { trigger } = useSWRMutation('/api/user', updateUserName)
+  const { data } = useSWR('/api/user', fetcher)
 
   return (
     <div>
@@ -344,6 +345,8 @@ function Profile () {
   )
 }
 ```
+Note that the value provided for `optimisticData` should be based on the data
+returned from `useSWR` as opposed to `useSWRMutation`'s data.
 
 ## Rollback on Errors [#rollback-on-errors]
 

--- a/pages/docs/mutation.es-ES.mdx
+++ b/pages/docs/mutation.es-ES.mdx
@@ -329,6 +329,7 @@ import useSWRMutation from 'swr/mutation'
 
 function Profile () {
   const { trigger } = useSWRMutation('/api/user', updateUserName)
+  const { data } = useSWR('/api/user', fetcher)
 
   return (
     <div>
@@ -345,6 +346,8 @@ function Profile () {
   )
 }
 ```
+Note that the value provided for `optimisticData` should be based on the data
+returned from `useSWR` as opposed to `useSWRMutation`'s data.
 
 ## Rollback on Errors [#rollback-on-errors]
 

--- a/pages/docs/mutation.fr-FR.mdx
+++ b/pages/docs/mutation.fr-FR.mdx
@@ -323,6 +323,7 @@ import useSWRMutation from 'swr/mutation'
 
 function Profile () {
   const { trigger } = useSWRMutation('/api/user', updateUserName)
+  const { data } = useSWR('/api/user', fetcher)
 
   return (
     <div>
@@ -339,6 +340,8 @@ function Profile () {
   )
 }
 ```
+Note that the value provided for `optimisticData` should be based on the data
+returned from `useSWR` as opposed to `useSWRMutation`'s data.
 
 ## Revenir en arrière sur les erreurs [#rollback-on-errors]
 

--- a/pages/docs/mutation.ja.mdx
+++ b/pages/docs/mutation.ja.mdx
@@ -329,6 +329,7 @@ import useSWRMutation from 'swr/mutation'
 
 function Profile () {
   const { trigger } = useSWRMutation('/api/user', updateUserName)
+  const { data } = useSWR('/api/user', fetcher)
 
   return (
     <div>
@@ -345,6 +346,8 @@ function Profile () {
   )
 }
 ```
+Note that the value provided for `optimisticData` should be based on the data
+returned from `useSWR` as opposed to `useSWRMutation`'s data.
 
 ## エラー時のロールバック [#rollback-on-errors]
 

--- a/pages/docs/mutation.ko.mdx
+++ b/pages/docs/mutation.ko.mdx
@@ -328,6 +328,7 @@ import useSWRMutation from 'swr/mutation'
 
 function Profile () {
   const { trigger } = useSWRMutation('/api/user', updateUserName)
+  const { data } = useSWR('/api/user', fetcher)
 
   return (
     <div>
@@ -344,6 +345,8 @@ function Profile () {
   )
 }
 ```
+Note that the value provided for `optimisticData` should be based on the data
+returned from `useSWR` as opposed to `useSWRMutation`'s data.
 
 ## 오류 시 롤백 [#rollback-on-errors]
 

--- a/pages/docs/mutation.pt-BR.mdx
+++ b/pages/docs/mutation.pt-BR.mdx
@@ -323,6 +323,7 @@ import useSWRMutation from 'swr/mutation'
 
 function Profile () {
   const { trigger } = useSWRMutation('/api/user', updateUserName)
+  const { data } = useSWR('/api/user', fetcher)
 
   return (
     <div>
@@ -339,6 +340,8 @@ function Profile () {
   )
 }
 ```
+Note that the value provided for `optimisticData` should be based on the data
+returned from `useSWR` as opposed to `useSWRMutation`'s data.
 
 ## Reversão de Erros [#rollback-on-errors]
 

--- a/pages/docs/mutation.ru.mdx
+++ b/pages/docs/mutation.ru.mdx
@@ -328,6 +328,7 @@ import useSWRMutation from 'swr/mutation'
 
 function Profile () {
   const { trigger } = useSWRMutation('/api/user', updateUserName)
+  const { data } = useSWR('/api/user', fetcher)
 
   return (
     <div>
@@ -344,6 +345,8 @@ function Profile () {
   )
 }
 ```
+Note that the value provided for `optimisticData` should be based on the data
+returned from `useSWR` as opposed to `useSWRMutation`'s data.
 
 ## Откат при ошибках [#rollback-on-errors]
 

--- a/pages/docs/mutation.zh-CN.mdx
+++ b/pages/docs/mutation.zh-CN.mdx
@@ -323,6 +323,7 @@ import useSWRMutation from 'swr/mutation'
 
 function Profile () {
   const { trigger } = useSWRMutation('/api/user', updateUserName)
+  const { data } = useSWR('/api/user', fetcher)
 
   return (
     <div>
@@ -339,6 +340,8 @@ function Profile () {
   )
 }
 ```
+Note that the value provided for `optimisticData` should be based on the data
+returned from `useSWR` as opposed to `useSWRMutation`'s data.
 
 ## 错误回滚 [#rollback-on-errors]
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->
This PR clarifies where `data` comes from under the section on [mutations with optimistic data](https://swr.vercel.app/docs/mutation#optimistic-updates):

```jsx
import useSWRMutation from 'swr/mutation'

function Profile () {
  const { trigger } = useSWRMutation('/api/user', updateUserName)
  const { data } = useSWR('/api/user', fetcher) // <--- Added

  return (
    <div>
      <h1>My name is {data.name}.</h1>
      <button onClick={async () => {
        const newName = data.name.toUpperCase()

        trigger(newName, {
          optimisticData: user => ({ ...user, name: newName }),
          rollbackOnError: true
        })
      }}>Uppercase my name!</button>
    </div>
  )
}
``` 
I have also added a short note under that code snippet to bring this to the reader's attention.

See also and closes https://github.com/vercel/swr/issues/2944

### Description

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


