### PR TITLE
docs: fix error(typo) on `with-nextjs page` example code

### DIFF
--- a/pages/docs/with-nextjs.en-US.mdx
+++ b/pages/docs/with-nextjs.en-US.mdx
@@ -30,7 +30,7 @@ You can mark your components with `'use client'` directive or import SWR from cl
 ```tsx filename="app/page.tsx" highlight={1} copy
 'use client'
 import useSWR from 'swr'
-export default Page() {
+export default function Page() {
   const { data } = useSWR('/api/user', fetcher)
   return <h1>{data.name}</h1>
 }
@@ -49,7 +49,7 @@ export const SWRProvider = ({ children }) => {
 ```tsx filename="app/page.tsx" copy
 // This is still a server component
 import { SWRProvider } from './swr-provider'
-export default Page() {
+export default function Page() {
   return (
     <SWRProvider>
       <h1>hello SWR</h1>
@@ -57,7 +57,6 @@ export default Page() {
   )
 }
 ```
-
 
 ## Client Side Data Fetching [#client-side-data-fetching]
 
@@ -80,6 +79,7 @@ Together with SWR, you can pre-render the page for SEO, and also have features s
 You can use the `fallback` option of [`SWRConfig`](/docs/global-configuration) to pass the pre-fetched data as the initial value of all SWR hooks.
 
 For example with `getStaticProps`:
+
 ```jsx
  export async function getStaticProps () {
   // `getStaticProps` is executed on the server side.

--- a/pages/docs/with-nextjs.es-ES.mdx
+++ b/pages/docs/with-nextjs.es-ES.mdx
@@ -30,7 +30,7 @@ You can mark your components with `'use client'` directive or import SWR from cl
 ```tsx filename="app/page.tsx" highlight={1} copy
 'use client'
 import useSWR from 'swr'
-export default Page() {
+export default function Page() {
   const { data } = useSWR('/api/user', fetcher)
   return <h1>{data.name}</h1>
 }
@@ -49,7 +49,7 @@ export const SWRProvider = ({ children }) => {
 ```tsx filename="app/page.tsx" copy
 // This is still a server component
 import { SWRProvider } from './swr-provider'
-export default Page() {
+export default function Page() {
   return (
     <SWRProvider>
       <h1>hello SWR</h1>
@@ -57,7 +57,6 @@ export default Page() {
   )
 }
 ```
-
 
 ## Client Side Data Fetching [#client-side-data-fetching]
 
@@ -80,6 +79,7 @@ Together with SWR, you can pre-render the page for SEO, and also have features s
 You can use the `fallback` option of [`SWRConfig`](/docs/global-configuration) to pass the pre-fetched data as the initial value of all SWR hooks.
 
 For example with `getStaticProps`:
+
 ```jsx
  export async function getStaticProps () {
   // `getStaticProps` is executed on the server side.

--- a/pages/docs/with-nextjs.fr-FR.mdx
+++ b/pages/docs/with-nextjs.fr-FR.mdx
@@ -30,7 +30,7 @@ You can mark your components with `'use client'` directive or import SWR from cl
 ```tsx filename="app/page.tsx" highlight={1} copy
 'use client'
 import useSWR from 'swr'
-export default Page() {
+export default function Page() {
   const { data } = useSWR('/api/user', fetcher)
   return <h1>{data.name}</h1>
 }
@@ -49,7 +49,7 @@ export const SWRProvider = ({ children }) => {
 ```tsx filename="app/page.tsx" copy
 // This is still a server component
 import { SWRProvider } from './swr-provider'
-export default Page() {
+export default function Page() {
   return (
     <SWRProvider>
       <h1>hello SWR</h1>
@@ -57,7 +57,6 @@ export default Page() {
   )
 }
 ```
-
 
 ## Client Side Data Fetching [#client-side-data-fetching]
 
@@ -80,6 +79,7 @@ Together with SWR, you can pre-render the page for SEO, and also have features s
 You can use the `fallback` option of [`SWRConfig`](/docs/global-configuration) to pass the pre-fetched data as the initial value of all SWR hooks.
 
 For example with `getStaticProps`:
+
 ```jsx
  export async function getStaticProps () {
   // `getStaticProps` is executed on the server side.

--- a/pages/docs/with-nextjs.ja.mdx
+++ b/pages/docs/with-nextjs.ja.mdx
@@ -30,7 +30,7 @@ import useSWR from 'swr' // ❌ これはサーバーコンポーネントでは
 ```tsx filename="app/page.tsx" highlight={1} copy
 'use client'
 import useSWR from 'swr'
-export default Page() {
+export default function Page() {
   const { data } = useSWR('/api/user', fetcher)
   return <h1>{data.name}</h1>
 }
@@ -49,7 +49,7 @@ export const SWRProvider = ({ children }) => {
 ```tsx filename="app/page.tsx" copy
 // これはサーバーコンポーネントです
 import { SWRProvider } from './swr-provider'
-export default Page() {
+export default function Page() {
   return (
     <SWRProvider>
       <h1>hello SWR</h1>
@@ -57,7 +57,6 @@ export default Page() {
   )
 }
 ```
-
 
 ## クライアントサイドでのデータフェッチ [#client-side-data-fetching]
 
@@ -80,6 +79,7 @@ SWR と組み合わせることで、SEO のためにページをプリレンダ
 [`SWRConfig`](/docs/global-configuration) の `fallback` オプションを使用して、事前に取得したデータをすべての SWR フックの初期値として渡すことができます。
 
 `getStaticProps` の例:
+
 ```jsx
  export async function getStaticProps () {
   // `getStaticProps` はサーバーサイドで実行されます

--- a/pages/docs/with-nextjs.ko.mdx
+++ b/pages/docs/with-nextjs.ko.mdx
@@ -30,7 +30,7 @@ You can mark your components with `'use client'` directive or import SWR from cl
 ```tsx filename="app/page.tsx" highlight={1} copy
 'use client'
 import useSWR from 'swr'
-export default Page() {
+export default function Page() {
   const { data } = useSWR('/api/user', fetcher)
   return <h1>{data.name}</h1>
 }
@@ -49,7 +49,7 @@ export const SWRProvider = ({ children }) => {
 ```tsx filename="app/page.tsx" copy
 // This is still a server component
 import { SWRProvider } from './swr-provider'
-export default Page() {
+export default function Page() {
   return (
     <SWRProvider>
       <h1>hello SWR</h1>
@@ -57,7 +57,6 @@ export default Page() {
   )
 }
 ```
-
 
 ## Client Side Data Fetching [#client-side-data-fetching]
 
@@ -80,6 +79,7 @@ Together with SWR, you can pre-render the page for SEO, and also have features s
 You can use the `fallback` option of [`SWRConfig`](/docs/global-configuration) to pass the pre-fetched data as the initial value of all SWR hooks.
 
 For example with `getStaticProps`:
+
 ```jsx
  export async function getStaticProps () {
   // `getStaticProps` is executed on the server side.

--- a/pages/docs/with-nextjs.pt-BR.mdx
+++ b/pages/docs/with-nextjs.pt-BR.mdx
@@ -31,7 +31,7 @@ Você pode marcar seus componentes com a diretiva `'use client'` ou importar o S
 'use client'
 import useSWR from 'swr'
 
-export default Page() {
+export default function Page() {
   const { data } = useSWR('/api/user', fetcher)
   return <h1>{data.name}</h1>
 }
@@ -52,7 +52,7 @@ export const SWRProvider = ({ children }) => {
 ```tsx filename="app/page.tsx" copy
 // This is still a server component
 import { SWRProvider } from './swr-provider'
-export default Page() {
+export default function Page() {
   return (
     <SWRProvider>
       <h1>ola SWR</h1>
@@ -60,7 +60,6 @@ export default Page() {
   )
 }
 ```
-
 
 ## Obtendo dados em Client-side [#client-side-data-fetching]
 
@@ -72,7 +71,7 @@ Funciona assim:
 - Então, busque os dados no lado do cliente e exiba-os quando estiver pronto.
 
 Essa estratégia funciona bem para páginas de dashboard de usuário, por exemplo. Como a página do dashboard é uma página privada e específica do usuário, o SEO não é relevante e a página não precisa ser pré-renderizada.
-Os dados são atualizados com frequência, o que requer a busca de dados no momento da solicitação. 
+Os dados são atualizados com frequência, o que requer a busca de dados no momento da solicitação.
 
 ## Pré-rendedrizando com dados padrão [#pre-rendering-with-default-data]
 
@@ -84,6 +83,7 @@ Junto com o SWR, você pode pré-renderizar a página para SEO e também ter rec
 Você pode usar a opção `fallback` de [`SWRConfig`](/docs/global-configuration) para passar os dados pré-buscados como o valor inicial de todos os hooks SWR.
 
 Por exemplo, com o `getStaticProps`:
+
 ```jsx
  export async function getStaticProps () {
   // `getStaticProps` é executado no lado do servidor.

--- a/pages/docs/with-nextjs.ru.mdx
+++ b/pages/docs/with-nextjs.ru.mdx
@@ -30,7 +30,7 @@ import useSWR from 'swr' // ❌ Недоступно в серверных ко�
 ```tsx filename="app/page.tsx" highlight={1} copy
 'use client'
 import useSWR from 'swr'
-export default Page() {
+export default function Page() {
   const { data } = useSWR('/api/user', fetcher)
   return <h1>{data.name}</h1>
 }
@@ -49,7 +49,7 @@ export const SWRProvider = ({ children }) => {
 ```tsx filename="app/page.tsx" copy
 // Это всё ещё серверный компонент
 import { SWRProvider } from './swr-provider'
-export default Page() {
+export default function Page() {
   return (
     <SWRProvider>
       <h1>hello SWR</h1>
@@ -79,6 +79,7 @@ export default Page() {
 Вы можете использовать параметр `fallback` в [`SWRConfig`](/docs/global-configuration), чтобы передать предварительно полученные данные в качестве начального значения для всех хуков SWR.
 
 Например, с использованием `getStaticProps`:
+
 ```jsx
  export async function getStaticProps () {
   // `getStaticProps` выполняется на стороне сервера.

--- a/pages/docs/with-nextjs.zh-CN.mdx
+++ b/pages/docs/with-nextjs.zh-CN.mdx
@@ -30,13 +30,13 @@ import useSWR from 'swr' // ❌ 在 Server components 中不可用
 ```tsx filename="app/page.tsx" highlight={1} copy
 'use client'
 import useSWR from 'swr'
-export default Page() {
+export default function Page() {
   const { data } = useSWR('/api/user', fetcher)
   return <h1>{data.name}</h1>
 }
 ```
 
-如果您需要在 Server Components `layout` 或者 `page` 中使用 `SWRConfig` 配置公共设置，请创建一个独立的 Provider Client Component 以初始化 Provider 和配置，然后在Server Component Pages中使用它。
+如果您需要在 Server Components `layout` 或者 `page` 中使用 `SWRConfig` 配置公共设置，请创建一个独立的 Provider Client Component 以初始化 Provider 和配置，然后在 Server Component Pages 中使用它。
 
 ```tsx filename="app/swr-provider.tsx" copy
 'use client';
@@ -49,7 +49,7 @@ export const SWRProvider = ({ children }) => {
 ```tsx filename="app/page.tsx" copy
 // 这仍然是一个 Server Component
 import { SWRProvider } from './swr-provider'
-export default Page() {
+export default function Page() {
   return (
     <SWRProvider>
       <h1>hello SWR</h1>
@@ -57,7 +57,6 @@ export default Page() {
   )
 }
 ```
-
 
 ## 客户端数据获取 [#client-side-data-fetching]
 
@@ -80,6 +79,7 @@ export default Page() {
 您可以使用 [`SWRConfig`](/docs/global-configuration) 的 `fallback` 选项来将预获取的数据作为所有 SWR Hook 的初始值。
 
 使用 `getStaticProps` 的例子：
+
 ```jsx
  export async function getStaticProps () {
   // `getStaticProps` 在服务端执行


### PR DESCRIPTION
- add missing 'function' on example code.


### Updating existing pages ✍️

- Add missing 'function' on example code. 
- https://swr.vercel.app/docs/with-nextjs

- BEFORE
```tsx filename="app/page.tsx" highlight={1} copy
'use client'
import useSWR from 'swr'
export default Page() {  //👈missing 'function' here
  const { data } = useSWR('/api/user', fetcher)
  return <h1>{data.name}</h1>
}
```

- AFTER
```tsx filename="app/page.tsx" highlight={1} copy
'use client'
import useSWR from 'swr'
export default function Page() {
  const { data } = useSWR('/api/user', fetcher)
  return <h1>{data.name}</h1>
}
```

### Description

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates



