### PR TITLE
docs: Add ko translations for missing pages and paragraphs

### DIFF
--- a/pages/docs/advanced/devtools.ko.mdx
+++ b/pages/docs/advanced/devtools.ko.mdx
@@ -1,20 +1,19 @@
 import { Callout } from 'nextra-theme-docs'
 
-# DevTools
-
+# 개발자 도구
 
 <Callout>
-  SWRDevTools is not an official project of Vercel.
+  SWRDevTools는 Vercel의 공식 프로젝트가 아닙니다.
 </Callout>
 
-[SWRDevTools](https://swr-devtools.vercel.app/) is a developer tool for SWR, which helps to debug your SWR cache and fetchers.
+[SWRDevTools](https://swr-devtools.vercel.app/)는 SWR 캐시 및 페처를 디버깅하는 데 도움이 되는 SWR용 개발자 도구입니다.
 
-
-You can install SWR DevTools from the extension pages and use it with zero settings!
+확장 페이지에서 SWR 개발자 도구를 설치하여 아무런 설정 없이 사용할 수 있습니다!
 
 - Chrome: https://chrome.google.com/webstore/detail/swr-devtools/liidbicegefhheghhjbomajjaehnjned
 - Firefox: https://addons.mozilla.org/en-US/firefox/addon/swr-devtools/
 
 After installing it, the SWR devtool panel will appear on browsers' developer tools.
+설치 후 브라우저의 개발자 도구에 SWR 개발자 도구 패널이 나타납니다.
 
-Checkout more information on the [website](https://swr-devtools.vercel.app/) and the [repository](https://github.com/koba04/swr-devtools)
+[웹사이트](https://swr-devtools.vercel.app/) 및 [리포지터리](https://github.com/koba04/swr-devtools)에서 자세한 정보를 확인하세요/

--- a/pages/docs/advanced/understanding.ko.mdx
+++ b/pages/docs/advanced/understanding.ko.mdx
@@ -1,59 +1,61 @@
 import { Callout } from 'nextra-theme-docs'
 import Video from 'components/video'
 
-# Understanding SWR
+# SWR 이해하기
 
-## State Machine [#state-machine]
+## 상태 머신 [#state-machine]
 
-`useSWR` returns `data`, `error`, `isLoading`, and `isValidating` depending on the state of the `fetcher` function. This diagrams describe how SWR returns values in some scenarios.
+`useSWR`은 `fetcher` 함수에 따라 `data`, `error`, `isLoading` 그리고 `isValidating`을 반환합니다. 이 다이어그램은 일부 시나리오에서 SWR이 값을 반환하는 방법을 설명합니다.
 
-### Fetch and Revalidate [#fetch-and-revalidate]
+### 데이터 가져오기 및 재검증 [#fetch-and-revalidate]
 
-This pattern is to fetch data and revalidate it later.
+이 패턴은 데이터를 가져온 후 나중에 다시 유효성을 검사하는 패턴입니다.
 
 ![A pattern for fetch and revalidate](/img/understanding/fetch-and-revalidate.svg)
 
-### Key Change [#key-change]
+### 키 변경 [#key-change]
 
 This pattern is to fetch data and change the key and revalidate it later.
+이 패턴은 데이터를 가져온 후 키를 변경하고 나중에 다시 검증(revalidate)하는 방식입니다.
 
 ![A pattern for key change](/img/understanding/key-change.svg)
 
-### Key Change + Previous Data [#key-change--previous-data]
+### 키 변경 + 이전 데이터 [#key-change--previous-data]
 
-This pattern is to fetch data and change the key and revalidate it later with the `keepPreviousData` option.
+이 패턴은 데이터를 가져온 후 키를 변경하고, `keepPreviousData` 옵션을 사용하여 기존 데이터를 유지한 채 나중에 다시 검증하는 방식입니다.
 
 ![A pattern for key change + previous data](/img/understanding/key-change-previous-data.svg)
 
-### Fallback [#fallback]
+### 폴백 [#fallback]
 
-This pattern is to fetch data and revalidate it later with fallback data.
+이 패턴은 데이터를 가져온 후, 폴백 데이터(fallback data)를 사용하여 나중에 다시 검증하는 방식입니다.
 
 ![A pattern for fallback](/img/understanding/fallback.svg)
 
-### Key Change + Fallback [#key-change--fallback]
+### 키 변경 + 폴백 [#key-change--fallback]
 
-This pattern is to fetch data and change the key and revalidate it later with fallback data.
+이 패턴은 데이터를 가져온 후 키를 변경하고, 폴백 데이터를 사용하여 나중에 다시 검증하는 방식입니다.
 
 ![A pattern for key change + fallback](/img/understanding/key-change-fallback.svg)
 
-### Key Change + Previous Data + Fallback [#key-change--previous-data--fallback]
+### 키 변경 + 이전 데이터 + 폴백 [#key-change--previous-data--fallback]
 
-This pattern is to fetch data and change the key and revalidate it later with the `keepPreviousData` option and fallback data.
+이 패턴은 데이터를 가져온 후 키를 변경하고, `keepPreviousData` 옵션과 폴백 데이터를 함께 사용하여 나중에 다시 검증하는 방식입니다.
 
 ![A pattern for key change + previous data + fallback](/img/understanding/key-change-previous-data-fallback.svg)
 
-## Combining with isLoading and isValidating for better UX [#combining-with-isloading-and-isvalidating-for-better-ux]
+## isLoading 및 isValidating을 활용한 UX 개선 [#combining-with-isloading-and-isvalidating-for-better-ux]
 
 Comparing to the existing `isValidating` value, `isLoading` is a new property that can help you for the more general loading cases for UX.
+기존의 `isValidating` 값과 비교했을 때, `isLoading`은 보다 일반적인 로딩 상태를 다루는 새로운 속성입니다.
 
-- `isValidating` becomes `true` whenever there is an ongoing request **whether the data is loaded or not**
-- `isLoading` becomes `true` when there is an ongoing request and **data is not loaded yet**.
+- `isValidating`은 **데이터가 로드되었는지 여부와 상관없이** 요청이 진행 중이면 항상 true가 됩니다.
+- `isLoading`은 요청이 진행 중이면서 **아직 데이터가 로드되지 않은 경우에만** true가 됩니다.
 
-Simply saying you can use `isValidating` for indicating everytime there is an ongoing revalidation, and `isLoading` for indicating that SWR is revalidating but there is no data yet to display.
+간단히 말해, `isValidating`은 재검증이 진행될 때마다 이를 나타내는 데 사용하고, `isLoading`은 SWR이 재검증 중이지만 아직 표시할 데이터가 없는 경우 이를 나타내는 데 사용할 수 있습니다.
 
 <Callout emoji="📝">
-  Fallback data and previous data are not considered "loaded data," so when you use fallback data or enable the keepPreviousData option, you might have data to display.
+  폴백 데이터와 이전 데이터는 "로드된 데이터"로 간주되지 않으므로 폴백 데이터를 사용하거나 keepPreviousData 옵션을 활성화하면 표시할 데이터가 있을 수 있습니다.
 </Callout>
 
 ```jsx
@@ -62,12 +64,12 @@ function Stock() {
     refreshInterval: 3000
   });
 
-  // If it's still loading the initial data, there is nothing to display.
-  // We return a skeleton here.
+  // 여전히 초기 데이터를 로드하는 중이라면 표시할 내용이 없습니다.
+  // 여기서 스켈레톤을 반환합니다.
   if (isLoading) return <div className="skeleton" />;
 
-  // Otherwise, display the data and a spinner that indicates a background
-  // revalidation.
+  // 그렇지 않으면 데이터와 배경을 나타내는 스피너를 표시합니다.
+  // 재검증합니다.
   return (
     <>
       <div>${data}</div>
@@ -79,11 +81,11 @@ function Stock() {
 
 ![An example of using the isLoading state](/img/understanding/isloading.gif)
 
-You can find the code example [here](https://codesandbox.io/s/swr-isloading-jtopow)
+코드 예제는 [여기](https://codesandbox.io/s/swr-isloading-jtopow)에서 찾을 수 있습니다.
 
-## Return previous data for better UX [#return-previous-data-for-better-ux]
+## 이전 데이터를 반환하여 UX 개선 [#return-previous-data-for-better-ux]
 
-When doing data fetching based on continuous user actions, e.g. real-time search when typing, keeping the previous fetched data can improve the UX a lot. `keepPreviousData` is an option to enable that behavior. Here's a simple search UI:
+입력 시 실시간으로 검색하는 것과 같이 지속적인 사용자 동작을 기반으로 데이터를 가져오는 경우 이전에 가져온 데이터를 유지하면 UX를 크게 개선할 수 있습니다. `keepPreviousData`는 해당 동작을 활성화하는 옵션입니다. 다음은 간단한 검색 UI입니다:
 
 ```jsx
 function Search() {
@@ -110,7 +112,7 @@ function Search() {
 }
 ```
 
-With `keepPreviousData` enabled, you will still get the previous data even if you change the SWR key and the data for the new key starts loading again.
+`keepPreviousData`를 활성화하면 SWR 키를 변경하고 새 키의 데이터가 다시 로딩되기 시작하더라도 이전 데이터를 계속 가져올 수 있습니다.
 
 <Video
   src="https://user-images.githubusercontent.com/3676859/163695903-a3eb1259-180e-41e0-821e-21c320201194.mp4"
@@ -118,8 +120,8 @@ With `keepPreviousData` enabled, you will still get the previous data even if yo
   ratio={640/730}
 />
 
-You can find the full code for this example here: https://codesandbox.io/s/swr-keeppreviousdata-fsjz3m.
+이 예제의 전체 코드는 여기에서 확인할 수 있습니다: https://codesandbox.io/s/swr-keeppreviousdata-fsjz3m.
 
-## Dependency Collection for performance [#dependency-collection-for-performance]
+## 성능을 위한 의존성 수집 [#dependency-collection-for-performance]
 
-SWR only triggers re-rendering when the states used in the component have been updated. If you only use `data` in the component, SWR ignores the updates of other properties like `isValidating`, and `isLoading`. This reduces rendering counts a lot. More information can be found [here](/docs/advanced/performance#dependency-collection).
+SWR은 컴포넌트에서 사용된 상태가 업데이트될 때만 리렌더링을 트리거합니다. 즉, 컴포넌트에서 `data`만 사용한다면, SWR은 `isValidating`이나 `isLoading` 같은 다른 속성의 변경을 무시합니다. 이를 통해 렌더링 횟수를 크게 줄일 수 있습니다. 더 자세한 내용은 [여기](/docs/advanced/performance#dependency-collection)에서 확인할 수 있습니다.

--- a/pages/docs/pagination.ko.mdx
+++ b/pages/docs/pagination.ko.mdx
@@ -343,16 +343,16 @@ function App () {
 ```
 
 <Callout emoji="⚠️">
-    The `previousPageData` argument of the `getKey` function becomes `null` when you enable the `parallel` option.
+  `parallel` 옵션을 활성화하면 `getKey` 함수의 `previousPageData` 인수가 `null`이 됩니다.
 </Callout>
 
-### Revalidate Specific Pages [#revalidate-specific-pages]
+### 특정 페이지 재검증 [#revalidate-specific-pages]
 
 <Callout emoji="✅">
-  Please update to the latest version (≥ 2.2.5) to use this API.
+  이 API를 사용하려면 최신 버전(≥ 2.2.5)으로 업데이트하세요.
 </Callout>
 
-The default behavior of the mutation of `useSWRInfinite` is to revalidate all pages that have been loaded. But you might want to revalidate only the specific pages that have been changed. You can revalidate only specific pages by passing a function to the `revalidate` option.
+`useSWRInfinite`의 기본 동작은 로드된 모든 페이지를 재검증하는 것입니다. 하지만 변경된 특정 페이지만 재검증하고 싶을 수도 있습니다. 이 경우, `revalidate` 옵션에 함수를 전달하여 특정 페이지만 재검증할 수 있습니다.
 
 ```jsx
 function App() {
@@ -362,7 +362,7 @@ function App() {
   );
 
   mutate(data, {
-    // only revalidate the last page
+    // 마지막 페이지에 대해서만 재검증을 수행
     revalidate: (pageData, [url, page]) => page === size
   });
 }

--- a/pages/docs/revalidation.ko.mdx
+++ b/pages/docs/revalidation.ko.mdx
@@ -87,14 +87,14 @@ useSWRImmutable(key, fetcher)
 
 위의 두 개의 hook은 **완전히 동일한** 작업을 수행합니다. 데이터가 캐시 되기만 하면 절대 다시 요청하지 않습니다.
 
-## Revalidate on Mount[#revalidate-on-mount]
+## 마운트 시 자동 갱신[#revalidate-on-mount]
 
-It's useful to force override SWR revalidation on mounting. By default, the value of `revalidateOnMount` is set to undefined.
+마운트 시 SWR의 재검증 동작을 강제로 변경하는 것이 유용할 수 있습니다. 기본적으로 `revalidateOnMount`의 값은 `undefined`로 설정되어 있습니다.
 
-A SWR hook mounts as:
+SWR 훅이 마운트될 때의 동작:
 
-- First it checks if `revalidateOnMount` is defined. It starts request if it's true, stop if it's false.
+- 먼저 `revalidateOnMount`가 정의되어 있는지 확인합니다. true이면 요청을 시작하고, false이면 요청을 중단합니다.
 
-`revalidateIfStale` useful to control the mount behaviour. By default `revalidateIfStale` is set to true.
+또한, `revalidateIfStale` 옵션은 마운트 시 자동 갱신 동작을 제어하는 데 유용합니다. 기본적으로 `revalidateIfStale`의 값은 true입니다.
 
-If `revalidateIfStale` is set to true it only refetches if there's any cache data else it will not refetch.
+`revalidateIfStale`가 true이면, 캐시된 데이터가 있을 경우에만 다시 가져오고, 캐시 데이터가 없으면 가져오지 않습니다.

--- a/pages/docs/with-nextjs.ko.mdx
+++ b/pages/docs/with-nextjs.ko.mdx
@@ -4,28 +4,28 @@ import { Callout } from 'nextra-theme-docs'
 
 ## App Router [#app-dir]
 
-### Server Components [#rsc]
+### 서버 컴포넌트 [#rsc]
 
 <Callout type="default" emoji="✅">
-   In Next.js App Router, all components are React Server Components (RSC) by default. **You could only import the key serialization APIs from SWR in RSC.**
+   Next.js의 App Router에서는 모든 컴포넌트가 기본적으로 React Server Component(RSC) 입니다. **따라서 RSC에서는 SWR의 키 직렬화(Key Serialization) API만 가져올 수 있습니다.**
 </Callout>
 
 ```tsx filename="app/page.tsx" copy
-import { unstable_serialize } from 'swr' // ✅ Available in server components
-import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ Available in server components
+import { unstable_serialize } from 'swr' // ✅ 서버 컴포넌트에서 사용 가능합니다.
+import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ 서버 컴포넌트에서 사용 가능합니다.
 ```
 
 <Callout type="error">
-   You could not import any other APIs from SWR since they are not available in RSC.
+   다른 API는 RSC에서 사용할 수 없으므로 SWR에서 가져올 수 없습니다.
 </Callout>
 
 ```tsx filename="app/page.tsx" highlight={1}
-import useSWR from 'swr' // ❌ This is not available in server components
+import useSWR from 'swr' // ❌ 서버 컴포넌트에서 사용할 수 없습니다.
 ```
 
-### Client Components
+### 클라이언트 컴포넌트
 
-You can mark your components with `'use client'` directive or import SWR from client components, both ways will allow you to use the SWR client data fetching hooks.
+컴포넌트에 `'use client'` 지시어를 추가하거나 클라이언트 컴포넌트에서 SWR을 가져오면, SWR의 클라이언트 데이터 페칭 훅을 사용할 수 있습니다.
 
 ```tsx filename="app/page.tsx" highlight={1} copy
 'use client'
@@ -36,7 +36,7 @@ export default function Page() {
 }
 ```
 
-If you need to use `SWRConfig` to configure global settings in server components `layout` or `page`, creating a separate provider client component to setup the provider and configuration then use it in the server component pages.
+서버 컴포넌트의 `layout` 또는 `page`에서 `SWRConfig`를 사용해 전역 설정을 구성해야 한다면, 별도의 클라이언트 프로바이더 컴포넌트를 만들어 설정을 적용한 후, 이를 서버 컴포넌트 페이지에서 사용하세요.
 
 ```tsx filename="app/swr-provider.tsx" copy
 'use client';
@@ -47,7 +47,7 @@ export const SWRProvider = ({ children }) => {
 ```
 
 ```tsx filename="app/page.tsx" copy
-// This is still a server component
+// 이것은 여전히 서버 컴포넌트입니다.
 import { SWRProvider } from './swr-provider'
 export default function Page() {
   return (
@@ -58,31 +58,31 @@ export default function Page() {
 }
 ```
 
-## Client Side Data Fetching [#client-side-data-fetching]
+## 클라이언트 사이드 데이터 페칭 [#client-side-data-fetching]
 
-If your page contains frequently updating data, and you don’t need to pre-render the data, SWR is a perfect fit and no special setup needed: just import `useSWR` and use the hook inside any components that use the data.
+페이지에 자주 변경되는 데이터가 포함되어 있고, 이를 사전 렌더링할 필요가 없다면, SWR이 최적의 선택입니다. 별도의 설정 없이 `useSWR`을 가져와서 데이터가 필요한 컴포넌트에서 훅을 사용하면 됩니다.
 
-Here’s how it works:
+동작 방식:
 
-- First, immediately show the page without data. You can show loading states for missing data.
-- Then, fetch the data on the client side and display it when ready.
+- 먼저, 데이터를 제외한 페이지를 즉시 렌더링합니다. 이때, 로딩 상태를 표시할 수 있습니다.
+- 클라이언트에서 데이터를 가져온 후, 준비되면 화면에 표시합니다.
 
-This approach works well for user dashboard pages, for example. Because a dashboard is a private, user-specific page, SEO is not relevant and the page doesn’t need to be pre-rendered. The data is frequently updated, which requires request-time data fetching.
+이 방식은 대시보드와 같은 사용자 전용 페이지에 적합합니다. 대시보드는 개인화된 페이지이므로 SEO가 중요하지 않으며, 사전 렌더링이 필요하지 않습니다. 또한, 데이터가 자주 변경되므로 요청 시점에 데이터를 가져오는 방식이 요구됩니다.
 
-## Pre-rendering with Default Data [#pre-rendering-with-default-data]
+## 기본 데이터를 이용한 사전 렌더링 [#pre-rendering-with-default-data]
 
-If the page must be pre-rendered, Next.js supports [2 forms of pre-rendering](https://nextjs.org/docs/basic-features/data-fetching):
-**Static Generation (SSG)** and **Server-side Rendering (SSR)**.
+페이지를 사전 렌더링해야 하는 경우, Next.js는 [두 가지 방식](https://nextjs.org/docs/basic-features/data-fetching)을 지원합니다:
+**정적 생성(SSG)**과 **서버 사이드 렌더링(SSR)**
 
-Together with SWR, you can pre-render the page for SEO, and also have features such as caching, revalidation, focus tracking, refetching on interval on the client side.
+SWR과 함께 사용하면, SEO를 위한 사전 렌더링과 더불어 클라이언트 측 캐싱, 재검증, 포커스 감지, 주기적인 데이터 갱신 같은 기능도 활용할 수 있습니다.
 
-You can use the `fallback` option of [`SWRConfig`](/docs/global-configuration) to pass the pre-fetched data as the initial value of all SWR hooks.
+사전 패칭된 데이터를 SWR 훅의 초기 값으로 설정하려면, [`SWRConfig`](/docs/global-configuration)의 `fallback` 옵션을 사용할 수 있습니다.
 
-For example with `getStaticProps`:
+`getStaticProps`에 대한 예시입니다:
 
 ```jsx
  export async function getStaticProps () {
-  // `getStaticProps` is executed on the server side.
+  // `getStaticProps`는 서버 측에서 실행됩니다.
   const article = await getArticleFromAPI()
   return {
     props: {
@@ -94,13 +94,13 @@ For example with `getStaticProps`:
 }
 
 function Article() {
-  // `data` will always be available as it's in `fallback`.
+  // `data`는 `fallback`에 있으므로 항상 사용할 수 있습니다.
   const { data } = useSWR('/api/article', fetcher)
   return <h1>{data.title}</h1>
 }
 
 export default function Page({ fallback }) {
-  // SWR hooks inside the `SWRConfig` boundary will use those values.
+  // `SWRConfig` 범위 안에 있는 SWR 훅은 해당 값을 사용하게 됩니다.
   return (
     <SWRConfig value={{ fallback }}>
       <Article />
@@ -110,14 +110,15 @@ export default function Page({ fallback }) {
 ```
 
 The page is still pre-rendered. It's SEO friendly, fast to response, but also fully powered by SWR on the client side. The data can be dynamic and self-updated over time.
+페이지는 여전히 사전 렌더링됩니다. SEO 친화적이고 응답 속도가 빠를 뿐만 아니라 클라이언트 측에서 SWR에 의해 완전히 구동됩니다. 데이터는 시간이 지남에 따라 동적으로 자체 업데이트될 수 있습니다.
 
 <Callout emoji="💡">
-  The `Article` component will render the pre-generated data first, and after the page is hydrated, it will fetch the latest data again to keep it refresh.
+  `Article` 컴포넌트는 미리 생성된 데이터를 사전 렌더링하고 페이지가 업데이트된 후 최신 데이터를 다시 가져와 최신 상태로 유지합니다.
 </Callout>
 
-### Complex Keys [#complex-keys]
+### 복합 키 [#complex-keys]
 
-`useSWR` can be used with keys that are `array` and `function` types. Utilizing pre-fetched data with these kinds of keys requires serializing the `fallback` keys with `unstable_serialize`.
+`useSWR`은 `array` 또는 `function` 형태의 키와 함께 사용할 수 있습니다. 이러한 키를 사용할 때 사전 패칭된 데이터를 적용하려면, `unstable_serialize`을 사용하여 `fallback` 키를 직렬화해야 합니다.
 
 ```jsx
 import useSWR, { unstable_serialize } from 'swr'
@@ -127,7 +128,7 @@ export async function getStaticProps () {
   return {
     props: {
       fallback: {
-        // unstable_serialize() array style key
+        // unstable_serialize() 배열 형태의 키
         [unstable_serialize(['api', 'article', 1])]: article,
       }
     }
@@ -135,7 +136,7 @@ export async function getStaticProps () {
 }
 
 function Article() {
-  // using an array style key.
+  // 배열 형태의 키를 사용하세요.
   const { data } = useSWR(['api', 'article', 1], fetcher)
   return <h1>{data.title}</h1>
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

Hi, Thanks for making great library. There were some Korean translations missing, so I added them

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates

### Updating existing pages ✍️

- Add ko translations for `with-nextjs.ko.mdx`, `advanced/understanding.ko.mdx`, `advanced/devtools.ko.mdx`
- Update ko translations for `pagination.ko.mdx`, `revalidation.ko.mdx`
