### PR TITLE
Remove suspense callout

### DIFF
--- a/pages/docs/suspense.en-US.mdx
+++ b/pages/docs/suspense.en-US.mdx
@@ -1,11 +1,5 @@
 import { Callout } from 'nextra-theme-docs'
 
-# Suspense
-
-<Callout emoji="🚨" type="error">
-  React still <strong>doesn't recommend</strong> using `Suspense` in data frameworks like SWR (<a href="https://reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">More information</a>). These APIs may change in the future as the results of our research.
-</Callout>
-
 You can enable the `suspense` option to use SWR with React Suspense:
 
 ```jsx

--- a/pages/docs/suspense.es-ES.mdx
+++ b/pages/docs/suspense.es-ES.mdx
@@ -1,11 +1,5 @@
 import { Callout } from 'nextra-theme-docs'
 
-# Suspense
-
-<Callout emoji="🚨" type="error">
-  React still <strong>doesn't recommend</strong> using `Suspense` in data frameworks like SWR (<a href="https://reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">More information</a>). These APIs may change in the future as the results of our research.
-</Callout>
-
 Puede activar la opción `suspense` para utilizar SWR con React Suspense:
 
 ```jsx

--- a/pages/docs/suspense.fr-FR.mdx
+++ b/pages/docs/suspense.fr-FR.mdx
@@ -1,11 +1,5 @@
 import { Callout } from 'nextra-theme-docs'
 
-# Suspense
-
-<Callout emoji="🚨" type="error">
-  React <strong>ne recommande toujours pas</strong> d'utiliser `Suspense` dans les frameworks de données comme SWR (<a href="https://reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">Plus d'informations</a>). Ces API peuvent changer à l'avenir en fonction des résultats de nos recherches.
-</Callout>
-
 Vous pouvez activer l'option `suspense` pour utiliser SWR avec React Suspense :
 
 ```jsx

--- a/pages/docs/suspense.ja.mdx
+++ b/pages/docs/suspense.ja.mdx
@@ -1,10 +1,5 @@
 import { Callout } from 'nextra-theme-docs'
 
-# サスペンス
-
-<Callout emoji="🚨" type="error">
-  React はまだサスペンスをデータ取得フレームワークである SWR などで使うことを <strong>推奨していません</strong> (<a href="https://reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">詳細</a>)。 これらの API は将来的に私たちの調査により変更される可能性があります。
-</Callout>
 
 React サスペンスで SWR を使用するには、 `suspense` オプションを有効にします。
 

--- a/pages/docs/suspense.ko.mdx
+++ b/pages/docs/suspense.ko.mdx
@@ -1,11 +1,5 @@
 import { Callout } from 'nextra-theme-docs'
 
-# 서스펜스
-
-<Callout emoji="🚨" type="error">
-  리액트는 여전히 SWR(<a href="https://reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">추가 정보</a>) 과 같은 데이터 프레임워크에서 서스펜스를 사용하는 것을 권장하지 않습니다. 이러한 API는 향후 연구 결과에 따라 변경될 수 있습니다.
-</Callout>
-
 React 서스펜스를 SWR과 함께 사용하려면 `suspense` 옵션을 활성화하세요.
 
 ```jsx

--- a/pages/docs/suspense.pt-BR.mdx
+++ b/pages/docs/suspense.pt-BR.mdx
@@ -1,11 +1,5 @@
 import { Callout } from 'nextra-theme-docs'
 
-# Suspense
-
-<Callout emoji="🚨" type="error">
-  O React <strong>não recomenda</strong> usar `Suspense` em frameworks de dados como o SWR (<a href="https://reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">Mais informações</a>). Essas APIs podem mudar no futuro como resultados da nossa pesquisa.
-</Callout>
-
 Você pode habilitar a opção `suspense` para usar SWR com React Suspense:
 
 ```jsx

--- a/pages/docs/suspense.ru.mdx
+++ b/pages/docs/suspense.ru.mdx
@@ -1,11 +1,5 @@
 import { Callout } from 'nextra-theme-docs'
 
-# Задержка (Suspense)
-
-<Callout emoji="🚨" type="error">
-  React по-прежнему <strong>не рекомендует</strong> использовать Suspense в таких фреймворках, как SWR. (<a href="https://ru.reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">Дополнительная информация</a>). По результатам нашего исследования эти API могут измениться в будущем.
-</Callout>
-
 Вы можете включить опцию `suspense`, чтобы использовать SWR с React Suspense:
 
 ```jsx

--- a/pages/docs/suspense.zh-CN.mdx
+++ b/pages/docs/suspense.zh-CN.mdx
@@ -1,10 +1,5 @@
 import { Callout } from 'nextra-theme-docs'
 
-# Suspense
-
-<Callout emoji="🚨" type="error">
-  React 仍然不建议在 SWR 这样的数据框架中使用 `Suspense` (<a href="https://reactjs.org/blog/2022/03/29/react-v18.html#suspense-in-data-frameworks" target="_blank" rel="noopener">更多信息</a>)。根据我们的调查结果，这些 API 将来可能会发生变化。
-</Callout>
 
 你可以启用 `suspense` 选项，从而让 SWR 和 React Suspense 一起使用：
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

Remove the suspense callout since its already stable in React 19 and useSWR utilizes [use](https://react.dev/reference/react/use) under the hood.

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


