### PR TITLE
Add a link to newer keepPreviousData option

### DIFF
--- a/pages/docs/middleware.en-US.mdx
+++ b/pages/docs/middleware.en-US.mdx
@@ -125,7 +125,8 @@ SWR Request: /api/user2
 Sometimes you want the data returned by `useSWR` to be "laggy". Even if the key changes,
 you still want it to return the previous result until the new data has loaded.
 
-This can be built as a laggy middleware together with `useRef`. In this example, we are also going to
+SWR provides this as a standard feature now via the [`keepPreviousData` option](/docs/advanced/understanding#return-previous-data-for-better-ux),
+but it could also be implemented as a laggy middleware together with `useRef`. In this example, we are also going to
 extend the returned object of the `useSWR` hook:
 
 ```jsx


### PR DESCRIPTION
- [ ] Adding new page
- [ ] Updating existing documentation
- [X] Other updates

The laggy middleware predates the `keepPreviousData` option. Now that `keepPreviousData` does the same thing as a standard feature, the docs should reflect that.