### PR TITLE
docs(graphql): update docs to fix invalid url as example

### DIFF
--- a/pages/docs/data-fetching.en-US.mdx
+++ b/pages/docs/data-fetching.en-US.mdx
@@ -56,7 +56,9 @@ Or using GraphQL with libs like [graphql-request](https://github.com/prisma-labs
 ```js
 import { request } from 'graphql-request'
 
-const fetcher = query => request('/api/graphql', query)
+const endpoint = 'https://example.com/graphql';
+
+const fetcher = query => request(endpoint, query)
 
 function App () {
   const { data, error } = useSWR(


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

If you follow the documentation for leveraging `graphql-request` you'll run into an "invalid URL" error thrown by `graphql-request`.

While this is an external dependency, it is still misleading.

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates


