### PR TITLE
docs: add onSuccess callback details to API documentation

### DIFF
--- a/content/docs/advanced/understanding.cn.mdx
+++ b/content/docs/advanced/understanding.cn.mdx
@@ -123,3 +123,76 @@ function Search() {
 ## 性能依赖关系收集 [#dependency-collection-for-performance]
 
 SWR 只会在组件中所使用的状态被更新时，触发重新渲染。如果只在组件中使用 `data`，SWR 将忽略其他属性（如 `isValidating` 和 `isLoading`）的更新。这大大减少了渲染次数。点击 [这里](/docs/advanced/performance#dependency-collection) 查看更多信息。
+
+## onSuccess Callback [#on-success-callback]
+
+Sometimes you may want to run some side effects right after the data is fetched successfully. You can use the `onSuccess` callback option to do that.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher, {
+  onSuccess: (data, key, config) => {
+    // Track successful API calls
+    analytics.track('API Success', {
+      endpoint: key,
+      timestamp: new Date(),
+      data: data
+    });
+  }
+});
+```
+
+SWR will call the `onSuccess` callback with the fetched data, the key, and the config object. This is useful for analytics, logging, or any other side effects you want to perform after a successful fetch.
+
+### `onSuccess` with deduplication
+
+One of the features of SWR is deduplication, which means that if the same key is being used in multiple places at the same time, SWR will only fetch the data once and share it among those components.
+
+Only the first `onSuccess` callback defined will be called for the first successful fetch, even if `onSuccess` is defined in multiple places.
+
+Example:
+
+```jsx
+const FirstComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // this on success will be called
+      console.log('First component success:', data);
+    }
+  });
+  return <div>{data?.name}</div>;
+};
+
+const SecondComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // this on success will NOT be called
+      console.log('Second component success:', data);
+    }
+  });
+  return <div>{data?.email}</div>;
+};
+
+const App = () => (
+  <>
+    <FirstComponent />
+    <SecondComponent />
+  </>
+);
+```
+
+The example above will only log the success message from the first component when the data is fetched successfully, even though both components have their own `onSuccess` callbacks. This is because SWR deduplicates requests for the same key.
+
+For this reason, you should avoid using `onSuccess` to set local state in the `onSuccess` callback, as it may lead to unexpected behavior when multiple components are using the same key.
+
+Also, the `onSuccess` callback is not called when the data is loaded from the cache, only when it is fetched from the network. If you need to run side effects for cached data, consider using the `useEffect` hook in combination with SWR's data.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher);
+
+useEffect(() => {
+  if (data) {
+    // Run side effects for cached data
+    console.log('Cached data:', data);
+  }
+}, [data]);
+```

--- a/content/docs/advanced/understanding.es.mdx
+++ b/content/docs/advanced/understanding.es.mdx
@@ -123,3 +123,76 @@ You can find the full code for this example here: https://codesandbox.io/s/swr-k
 ## Dependency Collection for performance [#dependency-collection-for-performance]
 
 SWR only triggers re-rendering when the states used in the component have been updated. If you only use `data` in the component, SWR ignores the updates of other properties like `isValidating`, and `isLoading`. This reduces rendering counts a lot. More information can be found [here](/docs/advanced/performance#dependency-collection).
+
+## onSuccess Callback [#on-success-callback]
+
+Sometimes you may want to run some side effects right after the data is fetched successfully. You can use the `onSuccess` callback option to do that.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher, {
+  onSuccess: (data, key, config) => {
+    // Track successful API calls
+    analytics.track('API Success', {
+      endpoint: key,
+      timestamp: new Date(),
+      data: data
+    });
+  }
+});
+```
+
+SWR will call the `onSuccess` callback with the fetched data, the key, and the config object. This is useful for analytics, logging, or any other side effects you want to perform after a successful fetch.
+
+### `onSuccess` with deduplication
+
+One of the features of SWR is deduplication, which means that if the same key is being used in multiple places at the same time, SWR will only fetch the data once and share it among those components.
+
+Only the first `onSuccess` callback defined will be called for the first successful fetch, even if `onSuccess` is defined in multiple places.
+
+Example:
+
+```jsx
+const FirstComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // this on success will be called
+      console.log('First component success:', data);
+    }
+  });
+  return <div>{data?.name}</div>;
+};
+
+const SecondComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // this on success will NOT be called
+      console.log('Second component success:', data);
+    }
+  });
+  return <div>{data?.email}</div>;
+};
+
+const App = () => (
+  <>
+    <FirstComponent />
+    <SecondComponent />
+  </>
+);
+```
+
+The example above will only log the success message from the first component when the data is fetched successfully, even though both components have their own `onSuccess` callbacks. This is because SWR deduplicates requests for the same key.
+
+For this reason, you should avoid using `onSuccess` to set local state in the `onSuccess` callback, as it may lead to unexpected behavior when multiple components are using the same key.
+
+Also, the `onSuccess` callback is not called when the data is loaded from the cache, only when it is fetched from the network. If you need to run side effects for cached data, consider using the `useEffect` hook in combination with SWR's data.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher);
+
+useEffect(() => {
+  if (data) {
+    // Run side effects for cached data
+    console.log('Cached data:', data);
+  }
+}, [data]);
+```

--- a/content/docs/advanced/understanding.fr.mdx
+++ b/content/docs/advanced/understanding.fr.mdx
@@ -122,3 +122,76 @@ Vous pouvez trouver l'exemple [ici](https://codesandbox.io/s/swr-keeppreviousdat
 ## Collection de dépendances pour les performances [#dependency-collection-for-performance]
 
 SWR ne déclenche le re-rendering que lorsque les états utilisés dans le composant ont été mis à jour. Si vous n'utilisez que `data` dans le composant, SWR ignore les mises à jour des autres propriétés comme `isValidating` et `isLoading`. Cela réduit considérablement le nombre de rendus. Vous pouvez trouver plus d'informations [ici](/docs/advanced/performance#dependency-collection).
+
+## onSuccess Callback [#on-success-callback]
+
+Sometimes you may want to run some side effects right after the data is fetched successfully. You can use the `onSuccess` callback option to do that.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher, {
+  onSuccess: (data, key, config) => {
+    // Track successful API calls
+    analytics.track('API Success', {
+      endpoint: key,
+      timestamp: new Date(),
+      data: data
+    });
+  }
+});
+```
+
+SWR will call the `onSuccess` callback with the fetched data, the key, and the config object. This is useful for analytics, logging, or any other side effects you want to perform after a successful fetch.
+
+### `onSuccess` with deduplication
+
+One of the features of SWR is deduplication, which means that if the same key is being used in multiple places at the same time, SWR will only fetch the data once and share it among those components.
+
+Only the first `onSuccess` callback defined will be called for the first successful fetch, even if `onSuccess` is defined in multiple places.
+
+Example:
+
+```jsx
+const FirstComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // this on success will be called
+      console.log('First component success:', data);
+    }
+  });
+  return <div>{data?.name}</div>;
+};
+
+const SecondComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // this on success will NOT be called
+      console.log('Second component success:', data);
+    }
+  });
+  return <div>{data?.email}</div>;
+};
+
+const App = () => (
+  <>
+    <FirstComponent />
+    <SecondComponent />
+  </>
+);
+```
+
+The example above will only log the success message from the first component when the data is fetched successfully, even though both components have their own `onSuccess` callbacks. This is because SWR deduplicates requests for the same key.
+
+For this reason, you should avoid using `onSuccess` to set local state in the `onSuccess` callback, as it may lead to unexpected behavior when multiple components are using the same key.
+
+Also, the `onSuccess` callback is not called when the data is loaded from the cache, only when it is fetched from the network. If you need to run side effects for cached data, consider using the `useEffect` hook in combination with SWR's data.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher);
+
+useEffect(() => {
+  if (data) {
+    // Run side effects for cached data
+    console.log('Cached data:', data);
+  }
+}, [data]);
+```

--- a/content/docs/advanced/understanding.ja.mdx
+++ b/content/docs/advanced/understanding.ja.mdx
@@ -123,3 +123,76 @@ function Search() {
 ## パフォーマンスのための依存収集 [#dependency-collection-for-performance]
 
 SWR はコンポーネントで使われているデータが更新された場合のみ再レンダリングします。コンポーネントの中で `data` しか使っていない場合、SWR は `isValidating` や `isLoading` のプロパティの更新を無視します。これはレンダリングの回数を減らします。詳細については [こちら](/docs/advanced/performance#dependency-collection)。
+
+## onSuccess Callback [#on-success-callback]
+
+Sometimes you may want to run some side effects right after the data is fetched successfully. You can use the `onSuccess` callback option to do that.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher, {
+  onSuccess: (data, key, config) => {
+    // Track successful API calls
+    analytics.track('API Success', {
+      endpoint: key,
+      timestamp: new Date(),
+      data: data
+    });
+  }
+});
+```
+
+SWR will call the `onSuccess` callback with the fetched data, the key, and the config object. This is useful for analytics, logging, or any other side effects you want to perform after a successful fetch.
+
+### `onSuccess` with deduplication
+
+One of the features of SWR is deduplication, which means that if the same key is being used in multiple places at the same time, SWR will only fetch the data once and share it among those components.
+
+Only the first `onSuccess` callback defined will be called for the first successful fetch, even if `onSuccess` is defined in multiple places.
+
+Example:
+
+```jsx
+const FirstComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // this on success will be called
+      console.log('First component success:', data);
+    }
+  });
+  return <div>{data?.name}</div>;
+};
+
+const SecondComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // this on success will NOT be called
+      console.log('Second component success:', data);
+    }
+  });
+  return <div>{data?.email}</div>;
+};
+
+const App = () => (
+  <>
+    <FirstComponent />
+    <SecondComponent />
+  </>
+);
+```
+
+The example above will only log the success message from the first component when the data is fetched successfully, even though both components have their own `onSuccess` callbacks. This is because SWR deduplicates requests for the same key.
+
+For this reason, you should avoid using `onSuccess` to set local state in the `onSuccess` callback, as it may lead to unexpected behavior when multiple components are using the same key.
+
+Also, the `onSuccess` callback is not called when the data is loaded from the cache, only when it is fetched from the network. If you need to run side effects for cached data, consider using the `useEffect` hook in combination with SWR's data.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher);
+
+useEffect(() => {
+  if (data) {
+    // Run side effects for cached data
+    console.log('Cached data:', data);
+  }
+}, [data]);
+```

--- a/content/docs/advanced/understanding.ko.mdx
+++ b/content/docs/advanced/understanding.ko.mdx
@@ -125,3 +125,76 @@ function Search() {
 ## 성능을 위한 의존성 수집 [#dependency-collection-for-performance]
 
 SWR은 컴포넌트에서 사용된 상태가 업데이트될 때만 리렌더링을 트리거합니다. 즉, 컴포넌트에서 `data`만 사용한다면, SWR은 `isValidating`이나 `isLoading` 같은 다른 속성의 변경을 무시합니다. 이를 통해 렌더링 횟수를 크게 줄일 수 있습니다. 더 자세한 내용은 [여기](/docs/advanced/performance#dependency-collection)에서 확인할 수 있습니다.
+
+## onSuccess Callback [#on-success-callback]
+
+Sometimes you may want to run some side effects right after the data is fetched successfully. You can use the `onSuccess` callback option to do that.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher, {
+  onSuccess: (data, key, config) => {
+    // Track successful API calls
+    analytics.track('API Success', {
+      endpoint: key,
+      timestamp: new Date(),
+      data: data
+    });
+  }
+});
+```
+
+SWR will call the `onSuccess` callback with the fetched data, the key, and the config object. This is useful for analytics, logging, or any other side effects you want to perform after a successful fetch.
+
+### `onSuccess` with deduplication
+
+One of the features of SWR is deduplication, which means that if the same key is being used in multiple places at the same time, SWR will only fetch the data once and share it among those components.
+
+Only the first `onSuccess` callback defined will be called for the first successful fetch, even if `onSuccess` is defined in multiple places.
+
+Example:
+
+```jsx
+const FirstComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // this on success will be called
+      console.log('First component success:', data);
+    }
+  });
+  return <div>{data?.name}</div>;
+};
+
+const SecondComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // this on success will NOT be called
+      console.log('Second component success:', data);
+    }
+  });
+  return <div>{data?.email}</div>;
+};
+
+const App = () => (
+  <>
+    <FirstComponent />
+    <SecondComponent />
+  </>
+);
+```
+
+The example above will only log the success message from the first component when the data is fetched successfully, even though both components have their own `onSuccess` callbacks. This is because SWR deduplicates requests for the same key.
+
+For this reason, you should avoid using `onSuccess` to set local state in the `onSuccess` callback, as it may lead to unexpected behavior when multiple components are using the same key.
+
+Also, the `onSuccess` callback is not called when the data is loaded from the cache, only when it is fetched from the network. If you need to run side effects for cached data, consider using the `useEffect` hook in combination with SWR's data.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher);
+
+useEffect(() => {
+  if (data) {
+    // Run side effects for cached data
+    console.log('Cached data:', data);
+  }
+}, [data]);
+```

--- a/content/docs/advanced/understanding.mdx
+++ b/content/docs/advanced/understanding.mdx
@@ -129,3 +129,76 @@ You can find the full code for this example here: https://codesandbox.io/s/swr-k
 ## Dependency Collection for performance [#dependency-collection-for-performance]
 
 SWR only triggers re-rendering when the states used in the component have been updated. If you only use `data` in the component, SWR ignores the updates of other properties like `isValidating`, and `isLoading`. This reduces rendering counts a lot. More information can be found [here](/docs/advanced/performance#dependency-collection).
+
+## onSuccess Callback [#on-success-callback]
+
+Sometimes you may want to run some side effects right after the data is fetched successfully. You can use the `onSuccess` callback option to do that.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher, {
+  onSuccess: (data, key, config) => {
+    // Track successful API calls
+    analytics.track('API Success', {
+      endpoint: key,
+      timestamp: new Date(),
+      data: data
+    });
+  }
+});
+```
+
+SWR will call the `onSuccess` callback with the fetched data, the key, and the config object. This is useful for analytics, logging, or any other side effects you want to perform after a successful fetch.
+
+### `onSuccess` with deduplication
+
+One of the features of SWR is deduplication, which means that if the same key is being used in multiple places at the same time, SWR will only fetch the data once and share it among those components.
+
+Only the first `onSuccess` callback defined will be called for the first successful fetch, even if `onSuccess` is defined in multiple places.
+
+Example:
+
+```jsx
+const FirstComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // this on success will be called
+      console.log('First component success:', data);
+    }
+  });
+  return <div>{data?.name}</div>;
+};
+
+const SecondComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // this on success will NOT be called
+      console.log('Second component success:', data);
+    }
+  });
+  return <div>{data?.email}</div>;
+};
+
+const App = () => (
+  <>
+    <FirstComponent />
+    <SecondComponent />
+  </>
+);
+```
+
+The example above will only log the success message from the first component when the data is fetched successfully, even though both components have their own `onSuccess` callbacks. This is because SWR deduplicates requests for the same key.
+
+For this reason, you should avoid using `onSuccess` to set local state in the `onSuccess` callback, as it may lead to unexpected behavior when multiple components are using the same key.
+
+Also, the `onSuccess` callback is not called when the data is loaded from the cache, only when it is fetched from the network. If you need to run side effects for cached data, consider using the `useEffect` hook in combination with SWR's data.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher);
+
+useEffect(() => {
+  if (data) {
+    // Run side effects for cached data
+    console.log('Cached data:', data);
+  }
+}, [data]);
+```

--- a/content/docs/advanced/understanding.pt.mdx
+++ b/content/docs/advanced/understanding.pt.mdx
@@ -123,3 +123,76 @@ Você pode achar o código completo para esse exemplo aqui: (https://codesandbox
 ## Coleção de Dependência para performance [#dependency-collection-for-performance]
 
 SWR apenas aciona a nova renderização quando os estados usados no componente forem atualizados. Se você apenas usar `data` no componente, o SWR irá ignorar as atualizações das outras propriedades como `isValidating` e `isLoading`. Isso reduz bastante o número de renderizações. Mais informações podem ser encontradas [aqui](/docs/advanced/performance#dependency-collection).
+
+## onSuccess Callback [#on-success-callback]
+
+Algumas vezes você pode querer rodar algum side-effect logo após seus dados serem requisitados com sucesso. Você pode usar a opçãp de callback `onSuccess` para fazer isso.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher, {
+  onSuccess: (data, key, config) => {
+    // Registra uma chamada de API com sucesso
+    analytics.track('API Sucesso', {
+      endpoint: key,
+      timestamp: new Date(),
+      data: data
+    });
+  }
+});
+```
+
+SWR vai chamar o callback `onSuccess` com o dado retornado, a chave, e o objeto de configuração. Isso é bastante útil para analytics, logging, ou qualquer outro side effect que você queira rodar depois de uma requisição bem-sucedida.
+
+### `onSuccess` com deduplicação
+
+Uma das features do SWR é a deduplicação, que significa que se a mesma chave estiver sendo usada em multiplos lugares ao mesmo tempo, o SWR vai fazer apenas uma requisisção e compartilhar o dado retornado entre os componentes.
+
+Somente a primeira função de callback `onSuccess` definida vai ser chamada para a primeira requisição feita com sucesso, mesmo se `onSuccess` estiver definido em multiplos lugares.
+
+Exemplo:
+
+```jsx
+const FirstComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // esse callback onSuccess será chamado
+      console.log('Primeiro component successo:', data);
+    }
+  });
+  return <div>{data?.name}</div>;
+};
+
+const SecondComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // esse callback onSuccess NÃO será chamado
+      console.log('Segundo componente successo:', data);
+    }
+  });
+  return <div>{data?.email}</div>;
+};
+
+const App = () => (
+  <>
+    <FirstComponent />
+    <SecondComponent />
+  </>
+);
+```
+
+O exemplo acima vai logar apenas a mensagem de sucesso do primeiro componente quando os dados forem retornados com sucesso, mesmo que ambos os componentes tenham seus próprios callbacks `onSuccess`. Isso acontece porque o SWR deduplica as requisições para a mesma chave.
+
+Por essa razão, você deve evitar user `onSuccess` para atualizar estado local, já que isso pode levar a comportamentes inexperados quando multiplos componente estiverem usando a mesma chave.
+
+Também, o callback `onSuccess` não é chamado quando o dados for carregado do cache, somente quando for retordado da rede. Se você precisa rodar qualquer side effect para dados cacheados, considere usar o hook `useEffect` em combinação com os dados do SWR.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher);
+
+useEffect(() => {
+  if (data) {
+    // Executar side effects para dados cacheados
+    console.log('Cached data:', data);
+  }
+}, [data]);
+```

--- a/content/docs/advanced/understanding.ru.mdx
+++ b/content/docs/advanced/understanding.ru.mdx
@@ -123,3 +123,76 @@ function Search() {
 ## Коллекция зависимостей для повышения производительности [#dependency-collection-for-performance]
 
 SWR запускает повторный рендеринг только тогда, когда состояния, используемые в компоненте, были обновлены. Если вы используете только `data` в компоненте, SWR игнорирует обновления других свойств, таких как `isValidating` и `isLoading`. Это значительно снижает количество рендеринга. Дополнительную информацию можно найти [здесь](/docs/advanced/performance#dependency-collection).
+
+## onSuccess Callback [#on-success-callback]
+
+Sometimes you may want to run some side effects right after the data is fetched successfully. You can use the `onSuccess` callback option to do that.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher, {
+  onSuccess: (data, key, config) => {
+    // Track successful API calls
+    analytics.track('API Success', {
+      endpoint: key,
+      timestamp: new Date(),
+      data: data
+    });
+  }
+});
+```
+
+SWR will call the `onSuccess` callback with the fetched data, the key, and the config object. This is useful for analytics, logging, or any other side effects you want to perform after a successful fetch.
+
+### `onSuccess` with deduplication
+
+One of the features of SWR is deduplication, which means that if the same key is being used in multiple places at the same time, SWR will only fetch the data once and share it among those components.
+
+Only the first `onSuccess` callback defined will be called for the first successful fetch, even if `onSuccess` is defined in multiple places.
+
+Example:
+
+```jsx
+const FirstComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // this on success will be called
+      console.log('First component success:', data);
+    }
+  });
+  return <div>{data?.name}</div>;
+};
+
+const SecondComponent = () => {
+  const { data } = useSWR('/api/user', fetcher, {
+    onSuccess: (data) => {
+      // this on success will NOT be called
+      console.log('Second component success:', data);
+    }
+  });
+  return <div>{data?.email}</div>;
+};
+
+const App = () => (
+  <>
+    <FirstComponent />
+    <SecondComponent />
+  </>
+);
+```
+
+The example above will only log the success message from the first component when the data is fetched successfully, even though both components have their own `onSuccess` callbacks. This is because SWR deduplicates requests for the same key.
+
+For this reason, you should avoid using `onSuccess` to set local state in the `onSuccess` callback, as it may lead to unexpected behavior when multiple components are using the same key.
+
+Also, the `onSuccess` callback is not called when the data is loaded from the cache, only when it is fetched from the network. If you need to run side effects for cached data, consider using the `useEffect` hook in combination with SWR's data.
+
+```jsx
+const { data } = useSWR('/api/user', fetcher);
+
+useEffect(() => {
+  if (data) {
+    // Run side effects for cached data
+    console.log('Cached data:', data);
+  }
+}, [data]);
+```

--- a/content/docs/api.cn.mdx
+++ b/content/docs/api.cn.mdx
@@ -17,7 +17,7 @@ const { data, error, isLoading, isValidating, mutate } = useSWR(key, fetcher, op
 
 - `data`: 通过 `fetcher` 用给定的 key 获取的数据（如未完全加载，返回 undefined）
 - `error`: `fetcher` 抛出的错误（或者是 undefined）
-- `isLoading`: 是否有一个正在进行中的请求且当前没有“已加载的数据“。预设数据及之前的数据不会被视为“已加载的数据“ 
+- `isLoading`: 是否有一个正在进行中的请求且当前没有“已加载的数据“。预设数据及之前的数据不会被视为“已加载的数据“
 - `isValidating`: 是否有请求或重新验证加载
 - `mutate(data?, options?)`: 更改缓存数据的函数 [（详情）](/docs/mutation)
 
@@ -48,7 +48,7 @@ const { data, error, isLoading, isValidating, mutate } = useSWR(key, fetcher, op
 - `strictServerPrefetchWarning = false`: 当 key 没有提供预填充数据时，在控制台显示警告消息 [（详情）](/docs/with-nextjs#prefetch-data-in-server-components)
 - `keepPreviousData = false`: 在新数据加载完成之前使用 key 上一次缓存过的数据 [（详情）](/docs/advanced/understanding#return-previous-data-for-better-ux)
 - `onLoadingSlow(key, config)`: 请求加载时间过长时的回调函数（参考 `loadingTimeout`）
-- `onSuccess(data, key, config)`: 请求成功完成时的回调函数
+- `onSuccess(data, key, config)`: 请求成功完成时的回调函数 [(details)](/docs/advanced/understanding#on-success-callback)
 - `onError(err, key, config)`: 请求返回错误时的回调函数
 - `onErrorRetry(err, key, config, revalidate, revalidateOps)`: 错误重试的处理函数
 - `onDiscarded(key)`: 请求由于竞态条件而被忽略时的回调函数

--- a/content/docs/api.es.mdx
+++ b/content/docs/api.es.mdx
@@ -49,7 +49,7 @@ Puede encontrar más información [aquí](/docs/advanced/understanding).
 - `strictServerPrefetchWarning = false`: mostrar un mensaje de advertencia en la consola cuando una key no tiene datos prellenados proporcionados [(detalles)](/docs/with-nextjs#prefetch-data-in-server-components)
 - `keepPreviousData = false`: devuelve la data anterior de la key hasta que se hayan cargado los nuevos datos [(detalles)](/docs/advanced/understanding#return-previous-data-for-better-ux)
 - `onLoadingSlow(key, config)`: función callback cuando una petición tarda demasiado en cargase (véase: `loadingTimeout`)
-- `onSuccess(data, key, config)`: función callback cuando una petición termina con éxito
+- `onSuccess(data, key, config)`: función callback cuando una petición termina con éxito [(details)](/docs/advanced/understanding#on-success-callback)
 - `onError(err, key, config)`: función callback cuando una petición devuelve un error
 - `onErrorRetry(err, key, config, revalidate, revalidateOps)`: manejador para el reintento de error
 - `onDiscarded(key)`: funciòn callback cuando una solicitud es ignorada debido a condiciones de carrera(race conditions)

--- a/content/docs/api.fr.mdx
+++ b/content/docs/api.fr.mdx
@@ -48,7 +48,7 @@ Plus d'informations [ici](/docs/advanced/understanding).
 - `strictServerPrefetchWarning = false`: afficher un message d'avertissement dans la console lorsqu'une clé n'a pas de données pré-remplies fournies [(détails)](/docs/with-nextjs#prefetch-data-in-server-components)
 - `keepPreviousData = false`: renvoyer les données de la clé précédente jusqu'à ce que les nouvelles données soient chargées [(détails)](/docs/advanced/understanding#return-previous-data-for-better-ux)
 - `onLoadingSlow(key, config)`: fonction de rappel lorsqu'une requête prend trop de temps à charger (voir `loadingTimeout`)
-- `onSuccess(data, key, config)`: fonction de rappel lorsqu'une requête se termine avec succès
+- `onSuccess(data, key, config)`: fonction de rappel lorsqu'une requête se termine avec succès [(details)](/docs/advanced/understanding#on-success-callback)
 - `onError(err, key, config)`: fonction de rappel lorsqu'une requête renvoie une erreur
 - `onErrorRetry(err, key, config, revalidate, revalidateOps)`: gestionnaire des nouvelles tentatives d'erreur
 - `onDiscarded(key)`: fonction de rappel lorsqu'une requête est ignorée en raison de conditions de course

--- a/content/docs/api.ja.mdx
+++ b/content/docs/api.ja.mdx
@@ -48,7 +48,7 @@ const { data, error, isLoading, isValidating, mutate } = useSWR(key, fetcher, op
 - `strictServerPrefetchWarning = false`: キーに事前入力されたデータが提供されていない場合、コンソールに警告メッセージを表示します [（ 詳細 ）](/docs/with-nextjs#prefetch-data-in-server-components)
 - `keepPreviousData = false`: 新しいキーに対するデータがロードされるまで以前のキーのデータを返すかどうか [（詳細）](/docs/advanced/understanding#return-previous-data-for-better-ux)
 - `onLoadingSlow(key, config)`: リクエストの読み込みに時間がかかりすぎる場合のコールバック関数（`loadingTimeout` を参照してください）
-- `onSuccess(data, key, config)`: リクエストが正常に終了したときのコールバック関数
+- `onSuccess(data, key, config)`: リクエストが正常に終了したときのコールバック関数 [(details)](/docs/advanced/understanding#on-success-callback)
 - `onError(err, key, config)`: リクエストがエラーを返したときのコールバック関数
 - `onErrorRetry(err, key, config, revalidate, revalidateOps)`: エラー再試行のハンドラー
 - `onDiscarded(key)`: レースコンディションによりリクエストが無視されたときのコールバック関数

--- a/content/docs/api.ko.mdx
+++ b/content/docs/api.ko.mdx
@@ -48,7 +48,7 @@ const { data, error, isLoading, isValidating, mutate } = useSWR(key, fetcher, op
 - `strictServerPrefetchWarning = false`: 키에 미리 채워진 데이터가 제공되지 않은 경우 콘솔에 경고 메시지 표시 [(상세내용)](/docs/with-nextjs#prefetch-data-in-server-components)
 - `keepPreviousData = false`: 새 데이터가 로드될 때까지 이전 키의 데이터를 반환 [(상세내용)](/docs/advanced/understanding#return-previous-data-for-better-ux)
 - `onLoadingSlow(key, config)`: 요청을 로드하는 데 너무 오래 걸리는 경우의 콜백 함수(`loadingTimeout`을 보세요)
-- `onSuccess(data, key, config)`: 요청이 성공적으로 종료되었을 경우의 콜백 함수
+- `onSuccess(data, key, config)`: 요청이 성공적으로 종료되었을 경우의 콜백 함수 [(details)](/docs/advanced/understanding#on-success-callback)
 - `onError(err, key, config)`: 요청이 에러를 반환했을 경우의 콜백 함수
 - `onErrorRetry(err, key, config, revalidate, revalidateOps)`: 에러 재시도 핸들러
 - `onDiscarded(key)`: 경합 상태(race condition)로 인해 요청이 무시될 경우 실행되는 콜백 함수

--- a/content/docs/api.mdx
+++ b/content/docs/api.mdx
@@ -54,7 +54,7 @@ More information can be found [here](/docs/advanced/understanding).
 - `strictServerPrefetchWarning = false`: show a warning message in the console when a key has no pre-filled data provided [(details)](/docs/with-nextjs#prefetch-data-in-server-components)
 - `keepPreviousData = false`: return the previous key's data until the new data has been loaded [(details)](/docs/advanced/understanding#return-previous-data-for-better-ux)
 - `onLoadingSlow(key, config)`: callback function when a request takes too long to load (see `loadingTimeout`)
-- `onSuccess(data, key, config)`: callback function when a request finishes successfully
+- `onSuccess(data, key, config)`: callback function when a request finishes successfully [(details)](/docs/advanced/understanding#on-success-callback)
 - `onError(err, key, config)`: callback function when a request returns an error
 - `onErrorRetry(err, key, config, revalidate, revalidateOps)`: handler for error retry
 - `onDiscarded(key)`: callback function when a request is ignored due to race conditions

--- a/content/docs/api.pt.mdx
+++ b/content/docs/api.pt.mdx
@@ -48,13 +48,13 @@ More information can be found [here](/docs/advanced/understanding).
 - `strictServerPrefetchWarning = false`: mostrar uma mensagem de aviso no console quando uma chave não tem dados pré-preenchidos fornecidos [(detalhes)](/docs/with-nextjs#prefetch-data-in-server-components)
 - `keepPreviousData = false`: return the previous key's data until the new data has been loaded [(detalhes)](/docs/advanced/understanding#return-previous-data-for-better-ux)
 - `onLoadingSlow(key, config)`: função callback quando um pedido demora muito tempo a carregar (veja `loadingTimeout`)
-- `onSuccess(data, key, config)`: função callback quando um pedido é bem-sucedido
+- `onSuccess(data, key, config)`: função callback quando um pedido é bem-sucedido [(detalhes)](/docs/advanced/understanding#on-success-callback)
 - `onError(err, key, config)`: função callback quando um pedido retorna um erro
 - `onErrorRetry(err, key, config, revalidate, revalidateOps)`: função callback quando um pedido retorna um erro
 - `onDiscarded(key)`: callback function when a request is ignored due to race conditions
 - `compare(a, b)`: função de comparação para detectar quando o dado retornado está diferente, para evitar rerenderizações desnecessárias. Por padrão, [stable-hash](https://github.com/shuding/stable-hash) é usado.
 - `isPaused()`: função para detectar quando o revalidador está pausado, e deve ignorar os dados e erros quando retorna `true`. Por padrão, retorna `false`.
-- `use`: array de middleware functions [(details)](/docs/middleware)
+- `use`: array de middleware functions [(detalhes)](/docs/middleware)
 
 <Callout emoji="💡">
 

--- a/content/docs/api.ru.mdx
+++ b/content/docs/api.ru.mdx
@@ -48,7 +48,7 @@ const { data, error, isLoading, isValidating, mutate } = useSWR(key, fetcher, op
 - `strictServerPrefetchWarning = false`: показывать предупреждающее сообщение в консоли, когда для ключа не предоставлены предварительно заполненные данные [(подробнее)](/docs/with-nextjs#prefetch-data-in-server-components)
 - `keepPreviousData = false`: возвращать данные предыдущего ключа, пока не будут загружены новые данные [(подробнее)](/docs/advanced/understanding#возврат-предыдущих-данных-для-лучшего-ux)
 - `onLoadingSlow(key, config)`: колбэк-функция, когда запрос загружается слишком долго (см. `loadingTimeout`)
-- `onSuccess(data, key, config)`: колбэк-функция при успешном завершении запроса
+- `onSuccess(data, key, config)`: колбэк-функция при успешном завершении запроса [(details)](/docs/advanced/understanding#on-success-callback)
 - `onError(err, key, config)`: колбэк-функция, когда запрос возвращает ошибку
 - `onErrorRetry(err, key, config, revalidate, revalidateOps)`: обработчик повторной попытки при ошибке
 - `onDiscarded(key)`: колбэк-функция, когда запрос игнорируется из-за состояния гонки


### PR DESCRIPTION
### Description

Detailing `onSucess` callback, when it runs and what case should be used.

- [ ] Adding new page
- [x ] Updating existing documentation
- [ ] Other updates


