### PR TITLE
fix: make redirects locale-aware

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -30,13 +30,28 @@ const config: NextConfig = {
         permanent: true
       },
       {
+        source: '/:locale/docs',
+        destination: '/:locale/docs/getting-started',
+        permanent: true
+      },
+      {
         source: '/blog',
         destination: '/blog/swr-v1',
         permanent: true
       },
       {
+        source: '/:locale/blog',
+        destination: '/:locale/blog/swr-v1',
+        permanent: true
+      },
+      {
         source: '/examples',
         destination: '/examples/basic',
+        permanent: true
+      },
+      {
+        source: '/:locale/examples',
+        destination: '/:locale/examples/basic',
         permanent: true
       },
 


### PR DESCRIPTION
### Description

This PR fixes an issue where top-level redirects were not fully locale-aware.

The site uses an i18n routing structure where the default locale does not have a URL prefix
(e.g. `/docs`), while non-default locales do (e.g. `/ja/docs`).
However, the existing redirect rules only covered non-prefixed routes, which caused 404 pages
when navigating the site in non-default languages via the header links or the "Get Started" CTA.

Since Next.js redirects are not locale-aware by default, both route patterns must be handled
explicitly.

### What was fixed

Redirect rules were updated to explicitly support both:

- Default locale routes (e.g. `/docs`, `/blog`, `/examples`)
- Locale-prefixed routes (e.g. `/:locale/docs`, `/:locale/blog`, `/:locale/examples`)

This ensures consistent navigation behavior across all supported languages.

### Redirect behavior

- `/docs` → `/docs/getting-started`
- `/:locale/docs` → `/:locale/docs/getting-started`
- `/blog` → `/blog/swr-v1`
- `/:locale/blog` → `/:locale/blog/swr-v1`
- `/examples` → `/examples/basic`
- `/:locale/examples` → `/:locale/examples/basic`

### Why this change is needed

- The issue only affects non-default locales, making it easy to miss during development.
- It breaks primary navigation and CTAs for localized users.
- The fix aligns with Next.js i18n routing behavior and avoids implicit assumptions about locales.

### Checklist

- [ ] Adding new page
- [ ] Updating existing documentation
- [x] Other updates (routing / redirect fix)

> Note:
> This description was written with AI assistance.
> Please feel free to suggest wording improvements if anything sounds unnatural.
