### PR TITLE
docs: mention displayedData in functional optimisticData

### DIFF
--- a/content/docs/mutation.mdx
+++ b/content/docs/mutation.mdx
@@ -321,6 +321,9 @@ function Profile () {
 }
 ```
 
+> The function receives `currentData` and `displayedData`. Use `displayedData` when you need
+> to chain optimistic updates on slow networks so the UI stays consistent between mutations.
+
 You can also create the same thing with `useSWRMutation` and `trigger`:
 
 ```jsx


### PR DESCRIPTION
Adds a short note that functional optimisticData receives (currentData, displayedData), matching vercel/swr#2668.\n\nCloses #510.