### PR TITLE
docs: guard localStorage example in cache provider

### DIFF
--- a/content/docs/advanced/cache.mdx
+++ b/content/docs/advanced/cache.mdx
@@ -101,6 +101,11 @@ You might want to sync your cache to `localStorage`. Here's an example implement
 
 ```jsx
 function localStorageProvider() {
+  // Guard against SSR where localStorage is not available.
+  if (typeof window === 'undefined') {
+    return new Map()
+  }
+
   // When initializing, we restore the data from `localStorage` into a map.
   const map = new Map(JSON.parse(localStorage.getItem('app-cache') || '[]'))
 


### PR DESCRIPTION
Adds an SSR guard to the LocalStorage-based persistent cache example so it doesn't access localStorage during server rendering.\n\nCloses #482.