### PR TITLE
docs: fix typo, usesSWRMutation → useSWRMutation

### DIFF
--- a/content/docs/with-nextjs.mdx
+++ b/content/docs/with-nextjs.mdx
@@ -31,7 +31,7 @@ import { SWRConfig } from 'swr' // ✅ Available in server components
 ```tsx filename="app/page.tsx" highlight={1}
 import useSWR from 'swr' // ❌ This is not available in server components
 import useSWRInfinite from 'swr/infinite' // ❌ This is not available in server components
-import usesSWRMutation from 'swr/mutation' // ❌ This is not available in server components
+import useSWRMutation from 'swr/mutation' // ❌ This is not available in server components
 ```
 
 ### Client Components


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates

There is no function `use"s"SWRMutation`