### PR TITLE
Document displayedData for functional optimisticData

### DIFF
--- a/content/docs/mutation.mdx
+++ b/content/docs/mutation.mdx
@@ -110,7 +110,7 @@ It broadcasts to SWR hooks under the same [cache provider](/docs/advanced/cache)
 - `key`: same as `useSWR`'s `key`, but a function behaves as [a filter function](/docs/mutation#mutate-multiple-items)
 - `data`: data to update the client cache, or an async function for the remote mutation
 - `options`: accepts the following options
-  - `optimisticData`: data to immediately update the client cache, or a function that receives current data and returns the new client cache data, usually used in optimistic UI.
+  - `optimisticData`: data to immediately update the client cache, or a function that receives `currentData` and `displayedData` and returns the new client cache data, usually used in optimistic UI.
   - `revalidate = true`: should the cache revalidate once the asynchronous update resolves. If set to a function, the function receives `data` and `key`.
   - `populateCache = true`: should the result of the remote mutation be written to the cache, or a function that receives new result and current result as arguments and returns the mutation result.
   - `rollbackOnError = true`: should the cache rollback if the remote mutation errors, or a function that receives the error thrown from fetcher as arguments and returns a boolean whether should rollback or not.
@@ -326,6 +326,23 @@ function Profile () {
     </div>
   )
 }
+```
+
+The functional form receives the last committed cache value as its first argument.
+It also receives the currently displayed value as the second argument. This is
+useful when multiple mutations can overlap, because the displayed value may
+already include an earlier optimistic update:
+
+```jsx
+const newTodo = { id: Date.now(), text: 'New todo' }
+
+mutate('/api/todos', addTodo(newTodo), {
+  optimisticData: (currentTodos = [], displayedTodos = currentTodos) => [
+    ...displayedTodos,
+    newTodo
+  ],
+  rollbackOnError: true
+})
 ```
 
 You can also create the same thing with `useSWRMutation` and `trigger`:


### PR DESCRIPTION
## Summary
- document that functional `optimisticData` receives both `currentData` and `displayedData`
- add an overlapping mutation example that uses `displayedData` to stack optimistic updates

Closes #510.

## Validation
- `git diff --check`