### PR TITLE
Clarify optimistic mutation docs

### DIFF
--- a/content/docs/mutation.cn.mdx
+++ b/content/docs/mutation.cn.mdx
@@ -320,9 +320,11 @@ function Profile () {
 你还可以通过 `useSWRMutation` 和 `trigger` 实现相同的功能：
 
 ```jsx
+import useSWR from 'swr'
 import useSWRMutation from 'swr/mutation'
 
 function Profile () {
+  const { data } = useSWR('/api/user', fetcher)
   const { trigger } = useSWRMutation('/api/user', updateUserName)
 
   return (

--- a/content/docs/mutation.es.mdx
+++ b/content/docs/mutation.es.mdx
@@ -325,9 +325,11 @@ function Profile () {
 You can also create the same thing with `useSWRMutation` and `trigger`:
 
 ```jsx
+import useSWR from 'swr'
 import useSWRMutation from 'swr/mutation'
 
 function Profile () {
+  const { data } = useSWR('/api/user', fetcher)
   const { trigger } = useSWRMutation('/api/user', updateUserName)
 
   return (

--- a/content/docs/mutation.fr.mdx
+++ b/content/docs/mutation.fr.mdx
@@ -320,9 +320,11 @@ function Profile () {
 Vous pouvez également créer la même chose avec `useSWRMutation` et `trigger` :
 
 ```jsx
+import useSWR from 'swr'
 import useSWRMutation from 'swr/mutation'
 
 function Profile () {
+  const { data } = useSWR('/api/user', fetcher)
   const { trigger } = useSWRMutation('/api/user', updateUserName)
 
   return (

--- a/content/docs/mutation.ja.mdx
+++ b/content/docs/mutation.ja.mdx
@@ -325,9 +325,11 @@ function Profile () {
 同様のことは `useSWRMutation` と `trigger` でも可能です。
 
 ```jsx
+import useSWR from 'swr'
 import useSWRMutation from 'swr/mutation'
 
 function Profile () {
+  const { data } = useSWR('/api/user', fetcher)
   const { trigger } = useSWRMutation('/api/user', updateUserName)
 
   return (

--- a/content/docs/mutation.ko.mdx
+++ b/content/docs/mutation.ko.mdx
@@ -325,9 +325,11 @@ function Profile () {
 `useSWRMutation` 및 `trigger`를 사용하여 동일한 작업을 수행할 수도 있습니다.
 
 ```jsx
+import useSWR from 'swr'
 import useSWRMutation from 'swr/mutation'
 
 function Profile () {
+  const { data } = useSWR('/api/user', fetcher)
   const { trigger } = useSWRMutation('/api/user', updateUserName)
 
   return (

--- a/content/docs/mutation.mdx
+++ b/content/docs/mutation.mdx
@@ -331,9 +331,11 @@ function Profile () {
 You can also create the same thing with `useSWRMutation` and `trigger`:
 
 ```jsx
+import useSWR from 'swr'
 import useSWRMutation from 'swr/mutation'
 
 function Profile () {
+  const { data } = useSWR('/api/user', fetcher)
   const { trigger } = useSWRMutation('/api/user', updateUserName)
 
   return (

--- a/content/docs/mutation.pt.mdx
+++ b/content/docs/mutation.pt.mdx
@@ -320,9 +320,11 @@ function Profile () {
 Você também pode criar a mesma coisa com `useSWRMutation` e `trigger`:
 
 ```jsx
+import useSWR from 'swr'
 import useSWRMutation from 'swr/mutation'
 
 function Profile () {
+  const { data } = useSWR('/api/user', fetcher)
   const { trigger } = useSWRMutation('/api/user', updateUserName)
 
   return (

--- a/content/docs/mutation.ru.mdx
+++ b/content/docs/mutation.ru.mdx
@@ -324,9 +324,11 @@ function Profile () {
 Вы также можете создать то же самое с помощью `useSWRMutation` и `trigger`:
 
 ```jsx
+import useSWR from 'swr'
 import useSWRMutation from 'swr/mutation'
 
 function Profile () {
+  const { data } = useSWR('/api/user', fetcher)
   const { trigger } = useSWRMutation('/api/user', updateUserName)
 
   return (


### PR DESCRIPTION
### Description

- Clarifies the `useSWRMutation` optimistic update example by showing that the current `/api/user` data is read with `useSWR`.
- Applies the same code example update across all mutation docs language files.
- Fixes vercel/swr#2944.

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates

### Validation

- `pnpm install --frozen-lockfile`
- `git diff --check`
- `pnpm build` currently fails in an unrelated existing TypeScript error: `components/ai-elements/message.tsx` references `mermaid` in the `plugins` object without an in-scope value.