### PR TITLE
Document typed tuple keys for useSWR

### DIFF
--- a/content/docs/typescript.cn.mdx
+++ b/content/docs/typescript.cn.mdx
@@ -45,6 +45,16 @@ const { data, error } = useSWR<User, Error>(uid, fetcher);
 // `error` 将会是 `Error | undefined`.
 ```
 
+If you specify both `Data` and `Error` and use an array key, specify the key type as the third generic so the `fetcher` argument stays typed:
+
+```typescript
+const { data, error } = useSWR<User, Error, [string, string]>(
+  ['/api/user', token],
+  ([url, token]) => fetchWithToken(url, token)
+)
+// `url` and `token` will be inferred as `string`.
+```
+
 ### useSWRInfinite [#useswrinfinite]
 
 同样适用于 `swr/infinite`，你可以依靠自动类型推断或自己显式地指定类型。

--- a/content/docs/typescript.es.mdx
+++ b/content/docs/typescript.es.mdx
@@ -45,6 +45,16 @@ const { data, error } = useSWR<User, Error>(uid, fetcher);
 // `error` will be `Error | undefined`.
 ```
 
+If you specify both `Data` and `Error` and use an array key, specify the key type as the third generic so the `fetcher` argument stays typed:
+
+```typescript
+const { data, error } = useSWR<User, Error, [string, string]>(
+  ['/api/user', token],
+  ([url, token]) => fetchWithToken(url, token)
+)
+// `url` and `token` will be inferred as `string`.
+```
+
 ### useSWRInfinite [#useswrinfinite]
 
 Same for `swr/infinite`, you can either rely on the automatic type inference or explicitly specify the types by yourself.

--- a/content/docs/typescript.fr.mdx
+++ b/content/docs/typescript.fr.mdx
@@ -45,6 +45,16 @@ const { data, error } = useSWR<User, Error>(uid, fetcher);
 // `error` sera `Error | undefined`.
 ```
 
+If you specify both `Data` and `Error` and use an array key, specify the key type as the third generic so the `fetcher` argument stays typed:
+
+```typescript
+const { data, error } = useSWR<User, Error, [string, string]>(
+  ['/api/user', token],
+  ([url, token]) => fetchWithToken(url, token)
+)
+// `url` and `token` will be inferred as `string`.
+```
+
 ### useSWRInfinite [#useswrinfinite]
 
 Comme pour `swr/infinite`, vous pouvez soit vous fier à l'inférence automatique des types, soit spécifier explicitement les types vous-même.

--- a/content/docs/typescript.ja.mdx
+++ b/content/docs/typescript.ja.mdx
@@ -45,6 +45,16 @@ const { data, error } = useSWR<User, Error>(uid, fetcher);
 // `error` は `Error | undefined` となります.
 ```
 
+If you specify both `Data` and `Error` and use an array key, specify the key type as the third generic so the `fetcher` argument stays typed:
+
+```typescript
+const { data, error } = useSWR<User, Error, [string, string]>(
+  ['/api/user', token],
+  ([url, token]) => fetchWithToken(url, token)
+)
+// `url` and `token` will be inferred as `string`.
+```
+
 ### useSWRInfinite [#useswrinfinite]
 
 `swr/infinite` の場合と同じように、型推論に頼るか、自分で明示的に型を指定することができます。

--- a/content/docs/typescript.ko.mdx
+++ b/content/docs/typescript.ko.mdx
@@ -45,6 +45,16 @@ const { data, error } = useSWR<User, Error>(uid, fetcher);
 // `error`는 `Error | undefined`입니다.
 ```
 
+If you specify both `Data` and `Error` and use an array key, specify the key type as the third generic so the `fetcher` argument stays typed:
+
+```typescript
+const { data, error } = useSWR<User, Error, [string, string]>(
+  ['/api/user', token],
+  ([url, token]) => fetchWithToken(url, token)
+)
+// `url` and `token` will be inferred as `string`.
+```
+
 ### useSWRInfinite [#useswrinfinite]
 
 `swr/infinite`와 마찬가지로, 자동 타입 추론에 의존하거나 직접 타입을 명시적으로 지정할 수 있습니다.

--- a/content/docs/typescript.mdx
+++ b/content/docs/typescript.mdx
@@ -50,6 +50,16 @@ const { data, error } = useSWR<User, Error>(uid, fetcher);
 // `error` will be `Error | undefined`.
 ```
 
+If you specify both `Data` and `Error` and use an array key, specify the key type as the third generic so the `fetcher` argument stays typed:
+
+```typescript
+const { data, error } = useSWR<User, Error, [string, string]>(
+  ['/api/user', token],
+  ([url, token]) => fetchWithToken(url, token)
+)
+// `url` and `token` will be inferred as `string`.
+```
+
 ### useSWRInfinite [#useswrinfinite]
 
 Same for `swr/infinite`, you can either rely on the automatic type inference or explicitly specify the types by yourself.

--- a/content/docs/typescript.pt.mdx
+++ b/content/docs/typescript.pt.mdx
@@ -37,6 +37,16 @@ const { data } = useSWR(uid, fetcher)
 // `data`será `User | undefined`.
 ```
 
+If you specify both `Data` and `Error` and use an array key, specify the key type as the third generic so the `fetcher` argument stays typed:
+
+```typescript
+const { data, error } = useSWR<User, Error, [string, string]>(
+  ['/api/user', token],
+  ([url, token]) => fetchWithToken(url, token)
+)
+// `url` and `token` will be inferred as `string`.
+```
+
 ### useSWRInfinite [#useswrinfinite]
 
 O mesmo para `swr/infinite`, você pode confiar na inferência automática de tipos ou especificar explicitamente os tipos por conta própria:

--- a/content/docs/typescript.ru.mdx
+++ b/content/docs/typescript.ru.mdx
@@ -45,6 +45,16 @@ const { data, error } = useSWR<User, Error>(uid, fetcher);
 // `error` будет `Error | undefined`.
 ```
 
+If you specify both `Data` and `Error` and use an array key, specify the key type as the third generic so the `fetcher` argument stays typed:
+
+```typescript
+const { data, error } = useSWR<User, Error, [string, string]>(
+  ['/api/user', token],
+  ([url, token]) => fetchWithToken(url, token)
+)
+// `url` and `token` will be inferred as `string`.
+```
+
 ### useSWRInfinite [#useswrinfinite]
 
 То же самое для `swr/infinite`, вы можете либо полагаться на автоматический вывод типа, либо явно указывать типы самостоятельно.


### PR DESCRIPTION
### Description

- Documents how to provide the key tuple type as the third `useSWR` generic when `Data` and `Error` are specified explicitly.
- Adds the tuple-key example across all TypeScript docs language files.
- Refs vercel/swr#3005.

- [ ] Adding new page
- [x] Updating existing documentation
- [ ] Other updates

### Validation

- `git diff --check`
- Verified the documented `useSWR<User, Error, [string, string]>` example with `tsc` against the built SWR package.
- `pnpm build` currently fails in an unrelated existing TypeScript error: `components/ai-elements/message.tsx` references `mermaid` in the `plugins` object without an in-scope value.