### PR TITLE
Document preload cacheData and unload APIs

### DIFF
--- a/components/ai-elements/message.tsx
+++ b/components/ai-elements/message.tsx
@@ -309,7 +309,7 @@ export const MessageResponse = memo(
         "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
         className
       )}
-      plugins={{ code, mermaid, math, cjk }}
+      plugins={{ code, cjk }}
       {...props}
     />
   ),

--- a/content/docs/advanced/cache.cn.mdx
+++ b/content/docs/advanced/cache.cn.mdx
@@ -163,3 +163,51 @@ mutate(
 ```
 
 More information can be found [here](/docs/arguments#multiple-arguments).
+
+## Clear the Cache [#clear-the-cache]
+
+<Callout>
+  This API requires SWR 2.5.0-beta.1 or later.
+</Callout>
+
+`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+
+By default, mounted hooks revalidate after the cache is cleared:
+
+```tsx
+import { unload } from 'swr'
+
+unload()
+```
+
+To clear the cache without immediately refetching, disable revalidation:
+
+```tsx
+unload({ revalidate: false })
+```
+
+Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+
+The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+
+```tsx
+import { useSWRConfig } from 'swr'
+
+function ClearCacheButton() {
+  const { unload } = useSWRConfig()
+
+  return (
+    <button onClick={() => unload({ revalidate: false })}>
+      Clear cache
+    </button>
+  )
+}
+```
+
+### API [#unload-api]
+
+```ts
+unload(options?: { revalidate?: boolean }): void
+```
+
+- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.

--- a/content/docs/advanced/cache.cn.mdx
+++ b/content/docs/advanced/cache.cn.mdx
@@ -164,15 +164,15 @@ mutate(
 
 More information can be found [here](/docs/arguments#multiple-arguments).
 
-## Clear the Cache [#clear-the-cache]
+## 清空缓存 [#clear-the-cache]
 
 <Callout>
-  This API requires SWR 2.5.0-beta.1 or later.
+  此 API 需要 SWR 2.5.0-beta.1 或更高版本。
 </Callout>
 
-`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+`unload()` 会清空缓存 provider 中的所有条目，并通知该 provider 作用域内所有已挂载的 hook。它还会清除待处理的预加载，并使 SWR 忽略已经在进行中的请求和数据更改结果。底层网络操作不会被中止。
 
-By default, mounted hooks revalidate after the cache is cleared:
+默认情况下，清空缓存后，已挂载的 hook 会重新验证：
 
 ```tsx
 import { unload } from 'swr'
@@ -180,15 +180,15 @@ import { unload } from 'swr'
 unload()
 ```
 
-To clear the cache without immediately refetching, disable revalidation:
+如果要清空缓存而不立即重新获取数据，请禁用重新验证：
 
 ```tsx
 unload({ revalidate: false })
 ```
 
-Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+这些 hook 会以 `data` 为 `undefined` 的状态重新渲染，并保持为空，直到焦点、重新连接或重新挂载等其他事件触发重新验证。`unload` 还会丢弃 `keepPreviousData` 保留的数据，并清除 `useSWRInfinite` 等 API 使用的内部 key；这些 key 可能无法被 `mutate` 的 key 过滤器匹配。
 
-The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+顶层导入绑定到 SWR 的默认缓存 provider。对于自定义 provider，请从 `useSWRConfig` 获取其作用域内的 `unload` 函数：
 
 ```tsx
 import { useSWRConfig } from 'swr'
@@ -198,7 +198,7 @@ function ClearCacheButton() {
 
   return (
     <button onClick={() => unload({ revalidate: false })}>
-      Clear cache
+      清空缓存
     </button>
   )
 }
@@ -210,4 +210,4 @@ function ClearCacheButton() {
 unload(options?: { revalidate?: boolean }): void
 ```
 
-- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.
+- `revalidate = true`：清空缓存后，重新验证已挂载 hook 使用的 key。

--- a/content/docs/advanced/cache.es.mdx
+++ b/content/docs/advanced/cache.es.mdx
@@ -163,3 +163,51 @@ mutate(
 ```
 
 More information can be found [here](/docs/arguments#multiple-arguments).
+
+## Clear the Cache [#clear-the-cache]
+
+<Callout>
+  This API requires SWR 2.5.0-beta.1 or later.
+</Callout>
+
+`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+
+By default, mounted hooks revalidate after the cache is cleared:
+
+```tsx
+import { unload } from 'swr'
+
+unload()
+```
+
+To clear the cache without immediately refetching, disable revalidation:
+
+```tsx
+unload({ revalidate: false })
+```
+
+Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+
+The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+
+```tsx
+import { useSWRConfig } from 'swr'
+
+function ClearCacheButton() {
+  const { unload } = useSWRConfig()
+
+  return (
+    <button onClick={() => unload({ revalidate: false })}>
+      Clear cache
+    </button>
+  )
+}
+```
+
+### API [#unload-api]
+
+```ts
+unload(options?: { revalidate?: boolean }): void
+```
+
+- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.

--- a/content/docs/advanced/cache.es.mdx
+++ b/content/docs/advanced/cache.es.mdx
@@ -164,15 +164,15 @@ mutate(
 
 More information can be found [here](/docs/arguments#multiple-arguments).
 
-## Clear the Cache [#clear-the-cache]
+## Vaciar la caché [#clear-the-cache]
 
 <Callout>
-  This API requires SWR 2.5.0-beta.1 or later.
+  Esta API requiere SWR 2.5.0-beta.1 o una versión posterior.
 </Callout>
 
-`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+`unload()` elimina todas las entradas de un proveedor de caché y notifica a todos los hooks montados dentro del ámbito de ese proveedor. También elimina las precargas pendientes y hace que SWR ignore los resultados de peticiones y mutaciones que ya estaban en curso. Las operaciones de red subyacentes no se cancelan.
 
-By default, mounted hooks revalidate after the cache is cleared:
+Por defecto, los hooks montados revalidan después de vaciar la caché:
 
 ```tsx
 import { unload } from 'swr'
@@ -180,15 +180,15 @@ import { unload } from 'swr'
 unload()
 ```
 
-To clear the cache without immediately refetching, disable revalidation:
+Para vaciar la caché sin volver a obtener los datos inmediatamente, desactiva la revalidación:
 
 ```tsx
 unload({ revalidate: false })
 ```
 
-Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+Esos hooks se vuelven a renderizar con `data` establecido en `undefined` y permanecen vacíos hasta que otro evento los revalide, como el enfoque de la ventana, la reconexión o un nuevo montaje. `unload` también descarta los datos conservados por `keepPreviousData` y elimina las keys internas utilizadas por APIs como `useSWRInfinite`, que un filtro de keys de `mutate` podría no encontrar.
 
-The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+La importación de nivel superior está vinculada al proveedor de caché predeterminado de SWR. Para un proveedor personalizado, obtén la función `unload` de su ámbito mediante `useSWRConfig`:
 
 ```tsx
 import { useSWRConfig } from 'swr'
@@ -198,7 +198,7 @@ function ClearCacheButton() {
 
   return (
     <button onClick={() => unload({ revalidate: false })}>
-      Clear cache
+      Vaciar caché
     </button>
   )
 }
@@ -210,4 +210,4 @@ function ClearCacheButton() {
 unload(options?: { revalidate?: boolean }): void
 ```
 
-- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.
+- `revalidate = true`: revalida las keys utilizadas por los hooks montados después de vaciar la caché.

--- a/content/docs/advanced/cache.fr.mdx
+++ b/content/docs/advanced/cache.fr.mdx
@@ -164,15 +164,15 @@ mutate(
 
 Plus d'informations peuvent être trouvées [ici](/docs/arguments#multiple-arguments).
 
-## Clear the Cache [#clear-the-cache]
+## Vider le cache [#clear-the-cache]
 
 <Callout>
-  This API requires SWR 2.5.0-beta.1 or later.
+  Cette API nécessite SWR 2.5.0-beta.1 ou une version ultérieure.
 </Callout>
 
-`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+`unload()` supprime toutes les entrées d'un fournisseur de cache et informe tous les hooks montés dans la portée de ce fournisseur. Il supprime également les préchargements en attente et demande à SWR d'ignorer les résultats des requêtes et mutations déjà en cours. Les opérations réseau sous-jacentes ne sont pas interrompues.
 
-By default, mounted hooks revalidate after the cache is cleared:
+Par défaut, les hooks montés revalident leurs données après le vidage du cache :
 
 ```tsx
 import { unload } from 'swr'
@@ -180,15 +180,15 @@ import { unload } from 'swr'
 unload()
 ```
 
-To clear the cache without immediately refetching, disable revalidation:
+Pour vider le cache sans récupérer immédiatement les données, désactivez la revalidation :
 
 ```tsx
 unload({ revalidate: false })
 ```
 
-Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+Ces hooks effectuent un nouveau rendu avec `data` défini sur `undefined` et restent vides jusqu'à ce qu'un autre événement déclenche leur revalidation, par exemple le focus, la reconnexion ou un nouveau montage. `unload` supprime également les données conservées par `keepPreviousData` ainsi que les clés internes utilisées par des API comme `useSWRInfinite`, qu'un filtre de clés de `mutate` pourrait ne pas trouver.
 
-The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+L'import de premier niveau est lié au fournisseur de cache par défaut de SWR. Pour un fournisseur personnalisé, récupérez la fonction `unload` propre à sa portée avec `useSWRConfig` :
 
 ```tsx
 import { useSWRConfig } from 'swr'
@@ -198,7 +198,7 @@ function ClearCacheButton() {
 
   return (
     <button onClick={() => unload({ revalidate: false })}>
-      Clear cache
+      Vider le cache
     </button>
   )
 }
@@ -210,4 +210,4 @@ function ClearCacheButton() {
 unload(options?: { revalidate?: boolean }): void
 ```
 
-- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.
+- `revalidate = true` : revalide les clés utilisées par les hooks montés après le vidage du cache.

--- a/content/docs/advanced/cache.fr.mdx
+++ b/content/docs/advanced/cache.fr.mdx
@@ -163,3 +163,51 @@ mutate(
 ```
 
 Plus d'informations peuvent être trouvées [ici](/docs/arguments#multiple-arguments).
+
+## Clear the Cache [#clear-the-cache]
+
+<Callout>
+  This API requires SWR 2.5.0-beta.1 or later.
+</Callout>
+
+`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+
+By default, mounted hooks revalidate after the cache is cleared:
+
+```tsx
+import { unload } from 'swr'
+
+unload()
+```
+
+To clear the cache without immediately refetching, disable revalidation:
+
+```tsx
+unload({ revalidate: false })
+```
+
+Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+
+The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+
+```tsx
+import { useSWRConfig } from 'swr'
+
+function ClearCacheButton() {
+  const { unload } = useSWRConfig()
+
+  return (
+    <button onClick={() => unload({ revalidate: false })}>
+      Clear cache
+    </button>
+  )
+}
+```
+
+### API [#unload-api]
+
+```ts
+unload(options?: { revalidate?: boolean }): void
+```
+
+- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.

--- a/content/docs/advanced/cache.ja.mdx
+++ b/content/docs/advanced/cache.ja.mdx
@@ -169,3 +169,51 @@ mutate(
 ```
 
 更なる情報は [こちら](/docs/arguments#multiple-arguments) から確認できます。
+
+## Clear the Cache [#clear-the-cache]
+
+<Callout>
+  This API requires SWR 2.5.0-beta.1 or later.
+</Callout>
+
+`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+
+By default, mounted hooks revalidate after the cache is cleared:
+
+```tsx
+import { unload } from 'swr'
+
+unload()
+```
+
+To clear the cache without immediately refetching, disable revalidation:
+
+```tsx
+unload({ revalidate: false })
+```
+
+Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+
+The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+
+```tsx
+import { useSWRConfig } from 'swr'
+
+function ClearCacheButton() {
+  const { unload } = useSWRConfig()
+
+  return (
+    <button onClick={() => unload({ revalidate: false })}>
+      Clear cache
+    </button>
+  )
+}
+```
+
+### API [#unload-api]
+
+```ts
+unload(options?: { revalidate?: boolean }): void
+```
+
+- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.

--- a/content/docs/advanced/cache.ja.mdx
+++ b/content/docs/advanced/cache.ja.mdx
@@ -170,15 +170,15 @@ mutate(
 
 更なる情報は [こちら](/docs/arguments#multiple-arguments) から確認できます。
 
-## Clear the Cache [#clear-the-cache]
+## キャッシュをクリアする [#clear-the-cache]
 
 <Callout>
-  This API requires SWR 2.5.0-beta.1 or later.
+  この API を利用するには SWR 2.5.0-beta.1 以降が必要です。
 </Callout>
 
-`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+`unload()` はキャッシュプロバイダー内のすべてのエントリを削除し、そのプロバイダーのスコープ内でマウントされているすべてのフックに通知します。また、保留中のプリロードを削除し、すでに実行中のリクエストやミューテーションの結果を SWR が無視するようにします。基盤となるネットワーク処理自体は中止されません。
 
-By default, mounted hooks revalidate after the cache is cleared:
+デフォルトでは、キャッシュのクリア後にマウント済みのフックが再検証されます。
 
 ```tsx
 import { unload } from 'swr'
@@ -186,15 +186,15 @@ import { unload } from 'swr'
 unload()
 ```
 
-To clear the cache without immediately refetching, disable revalidation:
+すぐに再取得せずにキャッシュをクリアするには、再検証を無効にします。
 
 ```tsx
 unload({ revalidate: false })
 ```
 
-Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+これらのフックは `data` が `undefined` の状態で再レンダリングされ、フォーカス、再接続、再マウントなどの別のイベントによって再検証されるまで空のままになります。`unload` は `keepPreviousData` が保持しているデータも破棄し、`mutate` のキーフィルターでは一致しない可能性がある `useSWRInfinite` などの API 用内部キーも削除します。
 
-The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+トップレベルの import は SWR のデフォルトキャッシュプロバイダーに紐づいています。カスタムプロバイダーでは、`useSWRConfig` からそのスコープに対応する `unload` 関数を取得してください。
 
 ```tsx
 import { useSWRConfig } from 'swr'
@@ -204,7 +204,7 @@ function ClearCacheButton() {
 
   return (
     <button onClick={() => unload({ revalidate: false })}>
-      Clear cache
+      キャッシュをクリア
     </button>
   )
 }
@@ -216,4 +216,4 @@ function ClearCacheButton() {
 unload(options?: { revalidate?: boolean }): void
 ```
 
-- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.
+- `revalidate = true`: キャッシュのクリア後に、マウント済みのフックが使用するキーを再検証します。

--- a/content/docs/advanced/cache.ko.mdx
+++ b/content/docs/advanced/cache.ko.mdx
@@ -170,15 +170,15 @@ mutate(
 
 More information can be found [here](/docs/arguments#multiple-arguments).
 
-## Clear the Cache [#clear-the-cache]
+## 캐시 비우기 [#clear-the-cache]
 
 <Callout>
-  This API requires SWR 2.5.0-beta.1 or later.
+  이 API를 사용하려면 SWR 2.5.0-beta.1 이상이 필요합니다.
 </Callout>
 
-`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+`unload()`는 캐시 프로바이더의 모든 항목을 지우고 해당 프로바이더 범위에 마운트된 모든 훅에 알립니다. 또한 대기 중인 프리로드를 지우고 SWR이 이미 진행 중인 요청과 뮤테이션의 결과를 무시하도록 합니다. 기반 네트워크 작업 자체가 중단되지는 않습니다.
 
-By default, mounted hooks revalidate after the cache is cleared:
+기본적으로 캐시를 비운 뒤 마운트된 훅이 재검증됩니다.
 
 ```tsx
 import { unload } from 'swr'
@@ -186,15 +186,15 @@ import { unload } from 'swr'
 unload()
 ```
 
-To clear the cache without immediately refetching, disable revalidation:
+즉시 다시 가져오지 않고 캐시를 비우려면 재검증을 비활성화하세요.
 
 ```tsx
 unload({ revalidate: false })
 ```
 
-Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+이 훅들은 `data`가 `undefined`인 상태로 다시 렌더링되며 포커스, 재연결, 재마운트 같은 다른 이벤트가 재검증할 때까지 빈 상태를 유지합니다. `unload`는 `keepPreviousData`가 유지한 데이터도 제거하고, `mutate` 키 필터로 찾지 못할 수 있는 `useSWRInfinite` 등의 API가 사용하는 내부 키도 지웁니다.
 
-The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+최상위 import는 SWR의 기본 캐시 프로바이더에 연결됩니다. 사용자 지정 프로바이더에서는 `useSWRConfig`로 해당 범위의 `unload` 함수를 가져오세요.
 
 ```tsx
 import { useSWRConfig } from 'swr'
@@ -204,7 +204,7 @@ function ClearCacheButton() {
 
   return (
     <button onClick={() => unload({ revalidate: false })}>
-      Clear cache
+      캐시 비우기
     </button>
   )
 }
@@ -216,4 +216,4 @@ function ClearCacheButton() {
 unload(options?: { revalidate?: boolean }): void
 ```
 
-- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.
+- `revalidate = true`: 캐시를 비운 뒤 마운트된 훅이 사용하는 키를 재검증합니다.

--- a/content/docs/advanced/cache.ko.mdx
+++ b/content/docs/advanced/cache.ko.mdx
@@ -169,3 +169,51 @@ mutate(
 ```
 
 More information can be found [here](/docs/arguments#multiple-arguments).
+
+## Clear the Cache [#clear-the-cache]
+
+<Callout>
+  This API requires SWR 2.5.0-beta.1 or later.
+</Callout>
+
+`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+
+By default, mounted hooks revalidate after the cache is cleared:
+
+```tsx
+import { unload } from 'swr'
+
+unload()
+```
+
+To clear the cache without immediately refetching, disable revalidation:
+
+```tsx
+unload({ revalidate: false })
+```
+
+Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+
+The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+
+```tsx
+import { useSWRConfig } from 'swr'
+
+function ClearCacheButton() {
+  const { unload } = useSWRConfig()
+
+  return (
+    <button onClick={() => unload({ revalidate: false })}>
+      Clear cache
+    </button>
+  )
+}
+```
+
+### API [#unload-api]
+
+```ts
+unload(options?: { revalidate?: boolean }): void
+```
+
+- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.

--- a/content/docs/advanced/cache.mdx
+++ b/content/docs/advanced/cache.mdx
@@ -168,3 +168,51 @@ mutate(
 ```
 
 More information can be found [here](/docs/arguments#multiple-arguments).
+
+## Clear the Cache [#clear-the-cache]
+
+<Callout>
+  This API requires SWR 2.5.0-beta.1 or later.
+</Callout>
+
+`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+
+By default, mounted hooks revalidate after the cache is cleared:
+
+```tsx
+import { unload } from 'swr'
+
+unload()
+```
+
+To clear the cache without immediately refetching, disable revalidation:
+
+```tsx
+unload({ revalidate: false })
+```
+
+Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+
+The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+
+```tsx
+import { useSWRConfig } from 'swr'
+
+function ClearCacheButton() {
+  const { unload } = useSWRConfig()
+
+  return (
+    <button onClick={() => unload({ revalidate: false })}>
+      Clear cache
+    </button>
+  )
+}
+```
+
+### API [#unload-api]
+
+```ts
+unload(options?: { revalidate?: boolean }): void
+```
+
+- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.

--- a/content/docs/advanced/cache.pt.mdx
+++ b/content/docs/advanced/cache.pt.mdx
@@ -172,3 +172,51 @@ mutate(
 ```
 
 Mais informação pode ser encontrada [aqui](/docs/arguments#multiple-arguments).
+
+## Clear the Cache [#clear-the-cache]
+
+<Callout>
+  This API requires SWR 2.5.0-beta.1 or later.
+</Callout>
+
+`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+
+By default, mounted hooks revalidate after the cache is cleared:
+
+```tsx
+import { unload } from 'swr'
+
+unload()
+```
+
+To clear the cache without immediately refetching, disable revalidation:
+
+```tsx
+unload({ revalidate: false })
+```
+
+Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+
+The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+
+```tsx
+import { useSWRConfig } from 'swr'
+
+function ClearCacheButton() {
+  const { unload } = useSWRConfig()
+
+  return (
+    <button onClick={() => unload({ revalidate: false })}>
+      Clear cache
+    </button>
+  )
+}
+```
+
+### API [#unload-api]
+
+```ts
+unload(options?: { revalidate?: boolean }): void
+```
+
+- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.

--- a/content/docs/advanced/cache.pt.mdx
+++ b/content/docs/advanced/cache.pt.mdx
@@ -173,15 +173,15 @@ mutate(
 
 Mais informação pode ser encontrada [aqui](/docs/arguments#multiple-arguments).
 
-## Clear the Cache [#clear-the-cache]
+## Limpar o cache [#clear-the-cache]
 
 <Callout>
-  This API requires SWR 2.5.0-beta.1 or later.
+  Esta API requer o SWR 2.5.0-beta.1 ou posterior.
 </Callout>
 
-`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+`unload()` remove todas as entradas de um provedor de cache e notifica todos os hooks montados no escopo desse provedor. Ele também remove pré-carregamentos pendentes e faz o SWR ignorar os resultados de requisições e mutações que já estavam em andamento. As operações de rede subjacentes não são interrompidas.
 
-By default, mounted hooks revalidate after the cache is cleared:
+Por padrão, os hooks montados revalidam depois que o cache é limpo:
 
 ```tsx
 import { unload } from 'swr'
@@ -189,15 +189,15 @@ import { unload } from 'swr'
 unload()
 ```
 
-To clear the cache without immediately refetching, disable revalidation:
+Para limpar o cache sem buscar novamente de imediato, desative a revalidação:
 
 ```tsx
 unload({ revalidate: false })
 ```
 
-Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+Esses hooks renderizam novamente com `data` definido como `undefined` e permanecem vazios até que outro evento os revalide, como foco, reconexão ou uma nova montagem. `unload` também descarta os dados mantidos por `keepPreviousData` e remove as chaves internas usadas por APIs como `useSWRInfinite`, que um filtro de chaves do `mutate` talvez não encontre.
 
-The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+A importação de nível superior está vinculada ao provedor de cache padrão do SWR. Para um provedor personalizado, obtenha a função `unload` do seu escopo com `useSWRConfig`:
 
 ```tsx
 import { useSWRConfig } from 'swr'
@@ -207,7 +207,7 @@ function ClearCacheButton() {
 
   return (
     <button onClick={() => unload({ revalidate: false })}>
-      Clear cache
+      Limpar cache
     </button>
   )
 }
@@ -219,4 +219,4 @@ function ClearCacheButton() {
 unload(options?: { revalidate?: boolean }): void
 ```
 
-- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.
+- `revalidate = true`: revalida as chaves usadas pelos hooks montados depois de limpar o cache.

--- a/content/docs/advanced/cache.ru.mdx
+++ b/content/docs/advanced/cache.ru.mdx
@@ -185,3 +185,51 @@ mutate(
 ```
 
 Дополнительную информацию можно найти [здесь](/docs/arguments#множественные-аргументы).
+
+## Clear the Cache [#clear-the-cache]
+
+<Callout>
+  This API requires SWR 2.5.0-beta.1 or later.
+</Callout>
+
+`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+
+By default, mounted hooks revalidate after the cache is cleared:
+
+```tsx
+import { unload } from 'swr'
+
+unload()
+```
+
+To clear the cache without immediately refetching, disable revalidation:
+
+```tsx
+unload({ revalidate: false })
+```
+
+Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+
+The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+
+```tsx
+import { useSWRConfig } from 'swr'
+
+function ClearCacheButton() {
+  const { unload } = useSWRConfig()
+
+  return (
+    <button onClick={() => unload({ revalidate: false })}>
+      Clear cache
+    </button>
+  )
+}
+```
+
+### API [#unload-api]
+
+```ts
+unload(options?: { revalidate?: boolean }): void
+```
+
+- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.

--- a/content/docs/advanced/cache.ru.mdx
+++ b/content/docs/advanced/cache.ru.mdx
@@ -186,15 +186,15 @@ mutate(
 
 Дополнительную информацию можно найти [здесь](/docs/arguments#множественные-аргументы).
 
-## Clear the Cache [#clear-the-cache]
+## Очистка кеша [#clear-the-cache]
 
 <Callout>
-  This API requires SWR 2.5.0-beta.1 or later.
+  Для этого API требуется SWR 2.5.0-beta.1 или более поздняя версия.
 </Callout>
 
-`unload()` clears every entry in a cache provider and notifies all mounted hooks in that provider scope. It also clears pending preloads and makes SWR ignore the results of requests and mutations that were already in flight. The underlying network operations are not aborted.
+`unload()` удаляет все записи из провайдера кеша и уведомляет все смонтированные хуки в области действия этого провайдера. Он также удаляет ожидающие предварительные загрузки и заставляет SWR игнорировать результаты уже выполняющихся запросов и мутаций. Сами сетевые операции при этом не прерываются.
 
-By default, mounted hooks revalidate after the cache is cleared:
+По умолчанию после очистки кеша смонтированные хуки выполняют ревалидацию:
 
 ```tsx
 import { unload } from 'swr'
@@ -202,15 +202,15 @@ import { unload } from 'swr'
 unload()
 ```
 
-To clear the cache without immediately refetching, disable revalidation:
+Чтобы очистить кеш без немедленного повторного получения данных, отключите ревалидацию:
 
 ```tsx
 unload({ revalidate: false })
 ```
 
-Those hooks re-render with `data` set to `undefined` and remain empty until another event revalidates them, such as focus, reconnect, or remount. `unload` also drops data retained by `keepPreviousData` and clears internal keys used by APIs such as `useSWRInfinite`, which a `mutate` key filter might not match.
+Эти хуки повторно рендерятся со значением `data`, равным `undefined`, и остаются пустыми, пока другое событие не запустит ревалидацию, например фокус, повторное подключение или повторное монтирование. `unload` также удаляет данные, сохраненные параметром `keepPreviousData`, и внутренние ключи API, таких как `useSWRInfinite`, которые фильтр ключей `mutate` может не найти.
 
-The top-level import is bound to SWR's default cache provider. For a custom provider, get the scoped `unload` function from `useSWRConfig`:
+Импорт верхнего уровня привязан к провайдеру кеша SWR по умолчанию. Для собственного провайдера получите функцию `unload` его области действия с помощью `useSWRConfig`:
 
 ```tsx
 import { useSWRConfig } from 'swr'
@@ -220,7 +220,7 @@ function ClearCacheButton() {
 
   return (
     <button onClick={() => unload({ revalidate: false })}>
-      Clear cache
+      Очистить кеш
     </button>
   )
 }
@@ -232,4 +232,4 @@ function ClearCacheButton() {
 unload(options?: { revalidate?: boolean }): void
 ```
 
-- `revalidate = true`: revalidate the keys used by mounted hooks after clearing the cache.
+- `revalidate = true`: выполнить ревалидацию ключей, используемых смонтированными хуками, после очистки кеша.

--- a/content/docs/global-configuration.cn.mdx
+++ b/content/docs/global-configuration.cn.mdx
@@ -127,7 +127,7 @@ function Page() {
 
 ### 访问全局配置 [#access-to-global-configurations]
 
-你可以使用 `useSWRConfig` hook 来获取全局配置，以及[`数据更改`](/docs/mutation)和[`缓存`](/docs/advanced/cache)：
+你可以使用 `useSWRConfig` hook 获取全局配置，以及[`数据更改`](/docs/mutation)、[`缓存`](/docs/advanced/cache)和 provider 作用域内的 [`unload`](/docs/advanced/cache#clear-the-cache) 函数：
 
 ```jsx
 import { useSWRConfig } from 'swr'

--- a/content/docs/global-configuration.cn.mdx
+++ b/content/docs/global-configuration.cn.mdx
@@ -133,7 +133,7 @@ function Page() {
 import { useSWRConfig } from 'swr'
 
 function Component () {
-  const { refreshInterval, mutate, cache, ...restConfig } = useSWRConfig()
+  const { refreshInterval, mutate, cache, unload, ...restConfig } = useSWRConfig()
 
   // ...
 }

--- a/content/docs/global-configuration.es.mdx
+++ b/content/docs/global-configuration.es.mdx
@@ -134,7 +134,7 @@ Puedes utilizar el hook `useSWRConfig`para obtener las configuraciones globales,
 import { useSWRConfig } from 'swr'
 
 function Component () {
-  const { refreshInterval, mutate, cache, ...restConfig } = useSWRConfig()
+  const { refreshInterval, mutate, cache, unload, ...restConfig } = useSWRConfig()
 
   // ...
 }

--- a/content/docs/global-configuration.es.mdx
+++ b/content/docs/global-configuration.es.mdx
@@ -128,7 +128,7 @@ Además de todas las [opciones](/docs/api) listadas, `SWRConfig` también acepta
 
 ### Acceso a configuraciones globales [#access-to-global-configurations]
 
-Puedes utilizar el hook `useSWRConfig`para obtener las configuraciones globales, así como [`mutate`](/docs/mutation) y [`cache`](/docs/advanced/cache):
+Puedes utilizar el hook `useSWRConfig` para obtener las configuraciones globales, así como [`mutate`](/docs/mutation), [`cache`](/docs/advanced/cache) y la función [`unload`](/docs/advanced/cache#clear-the-cache) vinculada al proveedor:
 
 ```jsx
 import { useSWRConfig } from 'swr'

--- a/content/docs/global-configuration.fr.mdx
+++ b/content/docs/global-configuration.fr.mdx
@@ -127,7 +127,7 @@ En plus de toutes les [options](/docs/api) répertoriées, `SWRConfig` accepte �
 
 ### Accès aux configurations globales [#access-to-global-configurations]
 
-Vous pouvez utiliser le hook `useSWRConfig` pour obtenir les configurations globales, ainsi que [`mutate`](/docs/mutation) et [`cache`](/docs/advanced/cache) :
+Vous pouvez utiliser le hook `useSWRConfig` pour obtenir les configurations globales, ainsi que [`mutate`](/docs/mutation), [`cache`](/docs/advanced/cache) et la fonction [`unload`](/docs/advanced/cache#clear-the-cache) propre au fournisseur :
 
 ```jsx
 import { useSWRConfig } from 'swr'

--- a/content/docs/global-configuration.fr.mdx
+++ b/content/docs/global-configuration.fr.mdx
@@ -133,7 +133,7 @@ Vous pouvez utiliser le hook `useSWRConfig` pour obtenir les configurations glob
 import { useSWRConfig } from 'swr'
 
 function Component () {
-  const { refreshInterval, mutate, cache, ...restConfig } = useSWRConfig()
+  const { refreshInterval, mutate, cache, unload, ...restConfig } = useSWRConfig()
 
   // ...
 }

--- a/content/docs/global-configuration.ja.mdx
+++ b/content/docs/global-configuration.ja.mdx
@@ -127,7 +127,7 @@ function Page() {
 
 ### グローバル設定へアクセス [#access-to-global-configurations]
 
-`useSWRConfig` フックを使ってグローバル設定、および[`ミューテーション`](/docs/mutation)と[`キャッシュ`](/docs/advanced/cache)を取得できます:
+`useSWRConfig` フックを使ってグローバル設定、[`ミューテーション`](/docs/mutation)、[`キャッシュ`](/docs/advanced/cache)、およびプロバイダーのスコープに紐づく [`unload`](/docs/advanced/cache#clear-the-cache) 関数を取得できます。
 
 ```jsx
 import { useSWRConfig } from 'swr'

--- a/content/docs/global-configuration.ja.mdx
+++ b/content/docs/global-configuration.ja.mdx
@@ -133,7 +133,7 @@ function Page() {
 import { useSWRConfig } from 'swr'
 
 function Component () {
-  const { refreshInterval, mutate, cache, ...restConfig } = useSWRConfig()
+  const { refreshInterval, mutate, cache, unload, ...restConfig } = useSWRConfig()
 
   // ...
 }

--- a/content/docs/global-configuration.ko.mdx
+++ b/content/docs/global-configuration.ko.mdx
@@ -133,7 +133,7 @@ function Page() {
 import { useSWRConfig } from 'swr'
 
 function Component () {
-  const { refreshInterval, mutate, cache, ...restConfig } = useSWRConfig()
+  const { refreshInterval, mutate, cache, unload, ...restConfig } = useSWRConfig()
 
   // ...
 }

--- a/content/docs/global-configuration.ko.mdx
+++ b/content/docs/global-configuration.ko.mdx
@@ -127,7 +127,7 @@ function Page() {
 
 ### 전역 설정에 접근하기 [#access-to-global-configurations]
 
-`useSWRConfig` hook을 사용해 전역 설정과 [`mutate`](/docs/mutation) 및 [`cache`](/docs/advanced/cache)를 얻을 수 있습니다.
+`useSWRConfig` hook을 사용해 전역 설정과 [`mutate`](/docs/mutation), [`cache`](/docs/advanced/cache), 프로바이더 범위의 [`unload`](/docs/advanced/cache#clear-the-cache) 함수를 얻을 수 있습니다.
 
 ```jsx
 import { useSWRConfig } from 'swr'

--- a/content/docs/global-configuration.mdx
+++ b/content/docs/global-configuration.mdx
@@ -133,13 +133,13 @@ Besides all the [options](/docs/api) listed, `SWRConfig` also accepts an optiona
 
 ### Access To Global Configurations [#access-to-global-configurations]
 
-You can use the `useSWRConfig` hook to get the global configurations, as well as [`mutate`](/docs/mutation) and [`cache`](/docs/advanced/cache):
+You can use the `useSWRConfig` hook to get the global configurations, as well as [`mutate`](/docs/mutation), [`cache`](/docs/advanced/cache), and the provider-scoped [`unload`](/docs/advanced/cache#clear-the-cache) function:
 
 ```jsx
 import { useSWRConfig } from 'swr'
 
 function Component () {
-  const { refreshInterval, mutate, cache, ...restConfig } = useSWRConfig()
+  const { refreshInterval, mutate, cache, unload, ...restConfig } = useSWRConfig()
 
   // ...
 }

--- a/content/docs/global-configuration.pt.mdx
+++ b/content/docs/global-configuration.pt.mdx
@@ -127,7 +127,7 @@ Além de todas as [opções](/docs/api) listadas, `SWRConfig` também aceita uma
 
 ### Acesso às Configurações Globais [#access-to-global-configurations]
 
-Você pode usar o hook `useSWRConfig` para obter as configurações globais, assim como [`mutate`](/docs/mutation) e [`cache`](/docs/advanced/cache):
+Você pode usar o hook `useSWRConfig` para obter as configurações globais, assim como [`mutate`](/docs/mutation), [`cache`](/docs/advanced/cache) e a função [`unload`](/docs/advanced/cache#clear-the-cache) do escopo do provedor:
 
 ```jsx
 import { useSWRConfig } from 'swr'

--- a/content/docs/global-configuration.pt.mdx
+++ b/content/docs/global-configuration.pt.mdx
@@ -133,7 +133,7 @@ Você pode usar o hook `useSWRConfig` para obter as configurações globais, ass
 import { useSWRConfig } from 'swr'
 
 function Component () {
-  const { refreshInterval, mutate, cache, ...restConfig } = useSWRConfig()
+  const { refreshInterval, mutate, cache, unload, ...restConfig } = useSWRConfig()
 
   // ...
 }

--- a/content/docs/global-configuration.ru.mdx
+++ b/content/docs/global-configuration.ru.mdx
@@ -128,8 +128,8 @@ function Page() {
 
 ### Доступ к глобальным конфигурациям [#access-to-global-configurations]
 
-Вы можете использовать ловушку `useSWRConfig` для получения глобальных конфигураций,
-а также [`mutate`](/docs/mutation) и [`cache`](/docs/advanced/cache):
+Вы можете использовать хук `useSWRConfig` для получения глобальных конфигураций,
+а также [`mutate`](/docs/mutation), [`cache`](/docs/advanced/cache) и привязанной к провайдеру функции [`unload`](/docs/advanced/cache#clear-the-cache):
 
 ```jsx
 import { useSWRConfig } from 'swr'

--- a/content/docs/global-configuration.ru.mdx
+++ b/content/docs/global-configuration.ru.mdx
@@ -135,7 +135,7 @@ function Page() {
 import { useSWRConfig } from 'swr'
 
 function Component () {
-  const { refreshInterval, mutate, cache, ...restConfig } = useSWRConfig()
+  const { refreshInterval, mutate, cache, unload, ...restConfig } = useSWRConfig()
 
   // ...
 }

--- a/content/docs/with-nextjs.cn.mdx
+++ b/content/docs/with-nextjs.cn.mdx
@@ -174,7 +174,7 @@ const cacheData = {
 
 通过使用 SWR, 您可以为了 SEO 预渲染页面, 并同时在客户端享受缓存、重新验证、焦点追踪、定时重新获取等特性。
 
-您可以使用 [`SWRConfig`](/docs/global-configuration) 的 `fallback` 选项来将预获取的数据作为所有 SWR Hook 的初始值。
+您可以使用 [`SWRConfig`](/docs/global-configuration) 的 `cacheData` 选项，将服务器获取的数据写入该边界内所有 SWR hook 的缓存。
 
 使用 `getStaticProps` 的例子：
 
@@ -184,7 +184,7 @@ const cacheData = {
   const article = await getArticleFromAPI()
   return {
     props: {
-      fallback: {
+      cacheData: {
         '/api/article': article
       }
     }
@@ -192,15 +192,15 @@ const cacheData = {
 }
 
 function Article() {
-  // `data` 将始终可用，因为其处于 `fallback` 列表中
+  // `data` 来自服务器提供的 `cacheData`
   const { data } = useSWR('/api/article', fetcher)
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   // 在 `SWRConfig` 标签内的 SWR hooks 将使用这些值
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )
@@ -210,12 +210,12 @@ export default function Page({ fallback }) {
 该页面仍然是预先生成，SEO 友好的，并且能够快速反应。然而该页面在客户端侧仍然完全由 SWR 驱动。数据仍然是动态的，且可以自动更新。
 
 <Callout emoji="💡">
-  `Article` 组件将先渲染预先生成的数据，并且在页面水合完成后将再次获取最新数据以保持数据最新
+  `Article` 组件会渲染预先生成的数据，并将其 hydration 到客户端缓存中，而不会发起重复的首次请求。后续的重新验证事件仍会使用客户端 fetcher。
 </Callout>
 
 ### 复杂关键字 [#complex-keys]
 
-`useSWR` 可以与 `array` 和 `function` 类型的 key 一同使用. 若要通过这些类型的 key 使用预先获取的数据，需要用 `unstable_serialize` 序列化 `fallback` key.
+`useSWR` 可以与 `array` 和 `function` 类型的 key 一同使用。手动创建 `cacheData` 时，需要使用 `unstable_serialize` 序列化这些 key。
 
 ```jsx
 import useSWR, { unstable_serialize } from 'swr'
@@ -224,7 +224,7 @@ export async function getStaticProps () {
   const article = await getArticleFromAPI(1)
   return {
     props: {
-      fallback: {
+      cacheData: {
         // unstable_serialize() array style key
         [unstable_serialize(['api', 'article', 1])]: article,
       }
@@ -238,9 +238,9 @@ function Article() {
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )

--- a/content/docs/with-nextjs.cn.mdx
+++ b/content/docs/with-nextjs.cn.mdx
@@ -16,7 +16,7 @@ import { unstable_serialize } from 'swr' // ✅ 在 Server components 中可用
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ 在 Server components 中可用
 
 import { SWRConfig } from 'swr' // ✅ 在 Server components 中可用
-import { preload } from 'swr' // ✅ Available in server components
+import { preload } from 'swr' // ✅ 在 Server Components 中可用
 ```
 
 <Callout type="error">
@@ -112,13 +112,13 @@ export default function Page() {
   要在应用程序中逐步采用此预获取模式，您可以启用 `strictServerPrefetchWarning` 选项。这将在控制台中显示警告消息，当某个 key 没有提供预填充数据时，帮助您识别哪些数据获取调用可以从服务器端预获取中受益。
 </Callout>
 
-### Preload Data into the Client Cache [#preload-data-into-client-cache]
+### 将数据预加载到客户端缓存 [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
-  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+  此功能需要 SWR 2.5.0-beta.1 或更高版本，目前仍处于实验阶段。
 </Callout>
 
-In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+在 Server Component 中，`preload(key, fetcher)` 会立即开始获取数据，并返回一个请求作用域内的 `CacheData` 对象。请将该对象传给 `SWRConfig` 的 `cacheData` 选项：
 
 ```tsx filename="app/page.tsx" copy
 import { preload, SWRConfig } from 'swr'
@@ -137,7 +137,7 @@ export default function Page() {
 }
 ```
 
-The client component uses the same key with its usual client-side fetcher:
+客户端组件使用相同的 key 和常规的客户端 fetcher：
 
 ```tsx filename="app/user.tsx" copy
 'use client'
@@ -152,9 +152,9 @@ export function User() {
 }
 ```
 
-SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+SWR 会在首次渲染时使用服务器加载的结果，在 hydration 期间将其写入客户端缓存，并跳过重复的首次客户端请求。后续的重新验证仍会使用客户端 fetcher。
 
-Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+每次调用 `preload` 都会返回一个新对象。合并这些对象即可预加载多个 key，无需等待它们完成：
 
 ```tsx
 const cacheData = {
@@ -163,7 +163,7 @@ const cacheData = {
 }
 ```
 
-`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
+`preload` 会自动序列化复杂的 SWR key。`cacheData` 选项仅由 `SWRConfig` 支持，不能直接传给 `useSWR`。
 
 ## 客户端数据获取 [#client-side-data-fetching]
 

--- a/content/docs/with-nextjs.cn.mdx
+++ b/content/docs/with-nextjs.cn.mdx
@@ -16,6 +16,7 @@ import { unstable_serialize } from 'swr' // ✅ 在 Server components 中可用
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ 在 Server components 中可用
 
 import { SWRConfig } from 'swr' // ✅ 在 Server components 中可用
+import { preload } from 'swr' // ✅ Available in server components
 ```
 
 <Callout type="error">
@@ -110,6 +111,59 @@ export default function Page() {
 <Callout type="default">
   要在应用程序中逐步采用此预获取模式，您可以启用 `strictServerPrefetchWarning` 选项。这将在控制台中显示警告消息，当某个 key 没有提供预填充数据时，帮助您识别哪些数据获取调用可以从服务器端预获取中受益。
 </Callout>
+
+### Preload Data into the Client Cache [#preload-data-into-client-cache]
+
+<Callout emoji="🧪">
+  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+</Callout>
+
+In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+
+```tsx filename="app/page.tsx" copy
+import { preload, SWRConfig } from 'swr'
+import { User } from './user'
+
+const getUser = () => fetchUserFromDatabase()
+
+export default function Page() {
+  const cacheData = preload('/api/user', getUser)
+
+  return (
+    <SWRConfig value={{ cacheData }}>
+      <User />
+    </SWRConfig>
+  )
+}
+```
+
+The client component uses the same key with its usual client-side fetcher:
+
+```tsx filename="app/user.tsx" copy
+'use client'
+
+import useSWR from 'swr'
+
+const fetcher = (url: string) => fetch(url).then(res => res.json())
+
+export function User() {
+  const { data } = useSWR('/api/user', fetcher)
+  return <h1>{data?.name}</h1>
+}
+```
+
+SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+
+Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+
+```tsx
+const cacheData = {
+  ...preload('/api/user', getUser),
+  ...preload('/api/posts', getPosts),
+}
+```
+
+`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
 
 ## 客户端数据获取 [#client-side-data-fetching]
 

--- a/content/docs/with-nextjs.cn.mdx
+++ b/content/docs/with-nextjs.cn.mdx
@@ -46,28 +46,19 @@ export default function Page() {
 
 ### 在服务器组件中预获取数据
 
-类似于 [带有默认数据的预渲染](#pre-rendering-with-default-data) 模式，使用 React Server Components (RSC) 你可以更进一步。
-
-您可以在服务器端 __启动__ 数据预获取，并通过 `<SWRConfig>` provider 的 `fallback` 选项将 __promise__ 传递给客户端组件树:
+在 React Server Components (RSC) 中，推荐使用 `preload` 开始获取数据，并通过 `<SWRConfig>` 的 `cacheData` 选项将返回的数据传给客户端组件树：
 
 ```tsx filename="app/layout.tsx" copy
-import { SWRConfig } from 'swr'
+import { preload, SWRConfig } from 'swr'
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
-  // 在服务器端启动数据获取
-  const userPromise = fetchUserFromAPI()
-  const postsPromise = fetchPostsFromAPI()
+  const cacheData = {
+    ...preload('/api/user', fetchUserFromAPI),
+    ...preload('/api/posts', fetchPostsFromAPI),
+  }
 
   return (
-    <SWRConfig
-      value={{
-        fallback: {
-          // 将 promise 传递给客户端组件
-          '/api/user': userPromise,
-          '/api/posts': postsPromise,
-        },
-      }}
-    >
+    <SWRConfig value={{ cacheData }}>
       {children}
     </SWRConfig>
   )
@@ -75,10 +66,10 @@ export default async function Layout({ children }: { children: React.ReactNode }
 ```
 
 <Callout emoji="💡">
-  这两个数据获取函数调用 `fetchUserFromAPI()` 和 `fetchPostsFromAPI()` 将在服务器端并行执行，因为我们不会立即 await 它们。
+  两次 `preload` 调用都会立即开始获取数据，因此这些请求会并行执行，无需在 layout 中等待。
 </Callout>
 
-在 React Server Components 中，您可以跨越 `"use client"` 边界传递 promise，SWR 将在服务端渲染期间自动解析它们:
+在 React Server Components 中，`cacheData` 内的 promise 可以跨越 `"use client"` 边界，SWR 会在服务端渲染期间自动解析它们：
 
 ```tsx filename="app/page.tsx" copy
 'use client'
@@ -86,7 +77,7 @@ export default async function Layout({ children }: { children: React.ReactNode }
 import useSWR from 'swr'
 
 export default function Page() {
-  // SWR 将解析从服务器组件传递的 promise
+  // SWR 会解析 Server Component 预加载的数据
   // 在 SSR 和客户端 hydration 期间，'user' 和 'posts' 都已准备就绪
   const { data: user } = useSWR('/api/user', fetcher)
   const { data: posts } = useSWR('/api/posts', fetcher)
@@ -104,15 +95,15 @@ export default function Page() {
 }
 ```
 
-然后，在客户端 SWR 将接管并保持与平常一样的行为。
+SWR 会在首次渲染时使用服务器加载的结果。在客户端，它会接管并继续执行常规的重新验证行为。
 
-通过将 promise 从服务器组件传递到客户端组件，数据获取可以尽可能早地在服务器端启动。并且只有实际使用数据的 UI 边界(最近的 `Suspense` 边界或 Next.js layout)才会在流式 SSR 期间被阻塞。
+通过 `preload` 和 `cacheData`，数据获取可以尽可能早地在服务器端开始。只有实际使用数据的 UI 边界（例如最近的 `Suspense` 边界或 Next.js layout）会在流式 SSR 期间被阻塞。
 
 <Callout type="default">
   要在应用程序中逐步采用此预获取模式，您可以启用 `strictServerPrefetchWarning` 选项。这将在控制台中显示警告消息，当某个 key 没有提供预填充数据时，帮助您识别哪些数据获取调用可以从服务器端预获取中受益。
 </Callout>
 
-### 将数据预加载到客户端缓存 [#preload-data-into-client-cache]
+### `cacheData` 的工作原理 [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
   此功能需要 SWR 2.5.0-beta.1 或更高版本，目前仍处于实验阶段。

--- a/content/docs/with-nextjs.es.mdx
+++ b/content/docs/with-nextjs.es.mdx
@@ -16,6 +16,7 @@ import { unstable_serialize } from 'swr' // ✅ Available in server components
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ Available in server components
 
 import { SWRConfig } from 'swr' // ✅ Available in server components
+import { preload } from 'swr' // ✅ Available in server components
 ```
 
 <Callout type="error">
@@ -110,6 +111,59 @@ By passing promises from Server Components to Client Components, the data fetchi
 <Callout type="default">
   Para adoptar incrementalmente este patrón de precarga en su aplicación, puede habilitar la opción `strictServerPrefetchWarning`. Esto mostrará un mensaje de advertencia en la consola cuando una clave no tiene datos prellenados proporcionados, ayudándole a identificar qué llamadas de obtención de datos podrían beneficiarse de la precarga del lado del servidor.
 </Callout>
+
+### Preload Data into the Client Cache [#preload-data-into-client-cache]
+
+<Callout emoji="🧪">
+  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+</Callout>
+
+In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+
+```tsx filename="app/page.tsx" copy
+import { preload, SWRConfig } from 'swr'
+import { User } from './user'
+
+const getUser = () => fetchUserFromDatabase()
+
+export default function Page() {
+  const cacheData = preload('/api/user', getUser)
+
+  return (
+    <SWRConfig value={{ cacheData }}>
+      <User />
+    </SWRConfig>
+  )
+}
+```
+
+The client component uses the same key with its usual client-side fetcher:
+
+```tsx filename="app/user.tsx" copy
+'use client'
+
+import useSWR from 'swr'
+
+const fetcher = (url: string) => fetch(url).then(res => res.json())
+
+export function User() {
+  const { data } = useSWR('/api/user', fetcher)
+  return <h1>{data?.name}</h1>
+}
+```
+
+SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+
+Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+
+```tsx
+const cacheData = {
+  ...preload('/api/user', getUser),
+  ...preload('/api/posts', getPosts),
+}
+```
+
+`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
 
 ## Client Side Data Fetching [#client-side-data-fetching]
 

--- a/content/docs/with-nextjs.es.mdx
+++ b/content/docs/with-nextjs.es.mdx
@@ -174,7 +174,7 @@ If the page must be pre-rendered, Next.js supports [2 forms of pre-rendering](ht
 
 Together with SWR, you can pre-render the page for SEO, and also have features such as caching, revalidation, focus tracking, refetching on interval on the client side.
 
-You can use the `fallback` option of [`SWRConfig`](/docs/global-configuration) to pass the pre-fetched data as the initial value of all SWR hooks.
+Puedes utilizar la opción `cacheData` de [`SWRConfig`](/docs/global-configuration) para guardar los datos obtenidos en el servidor en la caché de todos los hooks SWR dentro del límite.
 
 For example with `getStaticProps`:
 
@@ -184,7 +184,7 @@ For example with `getStaticProps`:
   const article = await getArticleFromAPI()
   return {
     props: {
-      fallback: {
+      cacheData: {
         '/api/article': article
       }
     }
@@ -192,15 +192,15 @@ For example with `getStaticProps`:
 }
 
 function Article() {
-  // `data` will always be available as it's in `fallback`.
+  // `data` está disponible mediante `cacheData`, proporcionado por el servidor.
   const { data } = useSWR('/api/article', fetcher)
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   // SWR hooks inside the `SWRConfig` boundary will use those values.
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )
@@ -210,12 +210,12 @@ export default function Page({ fallback }) {
 The page is still pre-rendered. It's SEO friendly, fast to response, but also fully powered by SWR on the client side. The data can be dynamic and self-updated over time.
 
 <Callout emoji="💡">
-  The `Article` component will render the pre-generated data first, and after the page is hydrated, it will fetch the latest data again to keep it refresh.
+  El componente `Article` renderiza los datos pregenerados y los hidrata en la caché del cliente sin duplicar la petición inicial. Los eventos de revalidación posteriores siguen utilizando el fetcher del cliente.
 </Callout>
 
 ### Complex Keys [#complex-keys]
 
-`useSWR` can be used with keys that are `array` and `function` types. Utilizing pre-fetched data with these kinds of keys requires serializing the `fallback` keys with `unstable_serialize`.
+`useSWR` admite keys de tipo `array` y `function`. Al crear `cacheData` manualmente, serializa estas keys con `unstable_serialize`.
 
 ```jsx
 import useSWR, { unstable_serialize } from 'swr'
@@ -224,7 +224,7 @@ export async function getStaticProps () {
   const article = await getArticleFromAPI(1)
   return {
     props: {
-      fallback: {
+      cacheData: {
         // unstable_serialize() array style key
         [unstable_serialize(['api', 'article', 1])]: article,
       }
@@ -238,9 +238,9 @@ function Article() {
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )

--- a/content/docs/with-nextjs.es.mdx
+++ b/content/docs/with-nextjs.es.mdx
@@ -46,28 +46,19 @@ export default function Page() {
 
 ### Prefetch Data in Server Components
 
-Similar to the [pre-rendering with default data](#pre-rendering-with-default-data) pattern, with React Server Components (RSC) you can go even further.
-
-You can __initiate__ the data prefetching on the server side and pass the __promise__ to client component tree via the `<SWRConfig>` provider's `fallback` option:
+El enfoque recomendado en React Server Components (RSC) es iniciar la obtención de datos con `preload` y pasar los datos devueltos al árbol de componentes cliente mediante la opción `cacheData` de `<SWRConfig>`:
 
 ```tsx filename="app/layout.tsx" copy
-import { SWRConfig } from 'swr'
+import { preload, SWRConfig } from 'swr'
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
-  // Initiate the data fetching on the server side.
-  const userPromise = fetchUserFromAPI()
-  const postsPromise = fetchPostsFromAPI()
+  const cacheData = {
+    ...preload('/api/user', fetchUserFromAPI),
+    ...preload('/api/posts', fetchPostsFromAPI),
+  }
 
   return (
-    <SWRConfig
-      value={{
-        fallback: {
-          // Pass the promises to client components.
-          '/api/user': userPromise,
-          '/api/posts': postsPromise,
-        },
-      }}
-    >
+    <SWRConfig value={{ cacheData }}>
       {children}
     </SWRConfig>
   )
@@ -75,10 +66,10 @@ export default async function Layout({ children }: { children: React.ReactNode }
 ```
 
 <Callout emoji="💡">
-  The two data fetching function calls `fetchUserFromAPI()` and `fetchPostsFromAPI()` will be executed in parallel on the server side because we don't await them immediately.
+  Ambas llamadas a `preload` comienzan a obtener datos inmediatamente, por lo que las peticiones se ejecutan en paralelo sin esperarlas en el layout.
 </Callout>
 
-In React Server Components, you can pass promises across the `"use client"` boundary, and SWR will resolve them automatically during Server-Side Rendering:
+En React Server Components, las promesas de `cacheData` pueden cruzar el límite `"use client"`, y SWR las resuelve automáticamente durante el renderizado del servidor:
 
 ```tsx filename="app/page.tsx" copy
 'use client'
@@ -86,7 +77,7 @@ In React Server Components, you can pass promises across the `"use client"` boun
 import useSWR from 'swr'
 
 export default function Page() {
-  // SWR will resolve the promise passed from server components.
+  // SWR resuelve los datos precargados por el Server Component.
   // Both `user` and `posts` are ready during SSR and client hydration.
   const { data: user } = useSWR('/api/user', fetcher)
   const { data: posts } = useSWR('/api/posts', fetcher)
@@ -104,15 +95,15 @@ export default function Page() {
 }
 ```
 
-Then, on the client-side SWR will take over and keep the behavior as usual.
+SWR utiliza el resultado cargado en el servidor para el renderizado inicial. En el cliente, toma el control y continúa con su comportamiento habitual de revalidación.
 
-By passing promises from Server Components to Client Components, the data fetching can be initiated as early as possible on the server side. And only the UI boundaries (closest `Suspense` boundary or Next.js layout) that actually consume the data will be blocked during streaming SSR.
+Con `preload` y `cacheData`, la obtención de datos comienza lo antes posible en el servidor. Solo se bloquean durante el streaming SSR los límites de UI que consumen los datos, como el límite `Suspense` más cercano o el layout de Next.js.
 
 <Callout type="default">
   Para adoptar incrementalmente este patrón de precarga en su aplicación, puede habilitar la opción `strictServerPrefetchWarning`. Esto mostrará un mensaje de advertencia en la consola cuando una clave no tiene datos prellenados proporcionados, ayudándole a identificar qué llamadas de obtención de datos podrían beneficiarse de la precarga del lado del servidor.
 </Callout>
 
-### Precargar datos en la caché del cliente [#preload-data-into-client-cache]
+### Cómo funciona `cacheData` [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
   Esta funcionalidad requiere SWR 2.5.0-beta.1 o una versión posterior y actualmente es experimental.

--- a/content/docs/with-nextjs.es.mdx
+++ b/content/docs/with-nextjs.es.mdx
@@ -16,7 +16,7 @@ import { unstable_serialize } from 'swr' // ✅ Available in server components
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ Available in server components
 
 import { SWRConfig } from 'swr' // ✅ Available in server components
-import { preload } from 'swr' // ✅ Available in server components
+import { preload } from 'swr' // ✅ Disponible en Server Components
 ```
 
 <Callout type="error">
@@ -112,13 +112,13 @@ By passing promises from Server Components to Client Components, the data fetchi
   Para adoptar incrementalmente este patrón de precarga en su aplicación, puede habilitar la opción `strictServerPrefetchWarning`. Esto mostrará un mensaje de advertencia en la consola cuando una clave no tiene datos prellenados proporcionados, ayudándole a identificar qué llamadas de obtención de datos podrían beneficiarse de la precarga del lado del servidor.
 </Callout>
 
-### Preload Data into the Client Cache [#preload-data-into-client-cache]
+### Precargar datos en la caché del cliente [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
-  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+  Esta funcionalidad requiere SWR 2.5.0-beta.1 o una versión posterior y actualmente es experimental.
 </Callout>
 
-In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+En un Server Component, `preload(key, fetcher)` inicia la obtención de datos inmediatamente y devuelve un objeto `CacheData` limitado a la petición. Pasa ese objeto a la opción `cacheData` de `SWRConfig`:
 
 ```tsx filename="app/page.tsx" copy
 import { preload, SWRConfig } from 'swr'
@@ -137,7 +137,7 @@ export default function Page() {
 }
 ```
 
-The client component uses the same key with its usual client-side fetcher:
+El componente cliente utiliza la misma key con su fetcher habitual del lado del cliente:
 
 ```tsx filename="app/user.tsx" copy
 'use client'
@@ -152,9 +152,9 @@ export function User() {
 }
 ```
 
-SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+SWR utiliza el resultado cargado en el servidor para el renderizado inicial, lo escribe en la caché del cliente durante la hidratación y evita duplicar la petición inicial del cliente. Las revalidaciones posteriores siguen utilizando el fetcher del cliente.
 
-Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+Cada llamada a `preload` devuelve un objeto nuevo. Combina los objetos para precargar varias keys sin esperarlas:
 
 ```tsx
 const cacheData = {
@@ -163,7 +163,7 @@ const cacheData = {
 }
 ```
 
-`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
+`preload` serializa automáticamente las keys complejas de SWR. La opción `cacheData` solo es compatible con `SWRConfig`; no se puede pasar directamente a `useSWR`.
 
 ## Client Side Data Fetching [#client-side-data-fetching]
 

--- a/content/docs/with-nextjs.fr.mdx
+++ b/content/docs/with-nextjs.fr.mdx
@@ -16,6 +16,7 @@ import { unstable_serialize } from 'swr' // ✅ Available in server components
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ Available in server components
 
 import { SWRConfig } from 'swr' // ✅ Available in server components
+import { preload } from 'swr' // ✅ Available in server components
 ```
 
 <Callout type="error">
@@ -110,6 +111,59 @@ By passing promises from Server Components to Client Components, the data fetchi
 <Callout type="default">
   Pour adopter progressivement ce modèle de préchargement dans votre application, vous pouvez activer l'option `strictServerPrefetchWarning`. Cela affichera un message d'avertissement dans la console lorsqu'une clé n'a pas de données pré-remplies fournies, vous aidant à identifier quels appels de récupération de données pourraient bénéficier d'un préchargement côté serveur.
 </Callout>
+
+### Preload Data into the Client Cache [#preload-data-into-client-cache]
+
+<Callout emoji="🧪">
+  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+</Callout>
+
+In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+
+```tsx filename="app/page.tsx" copy
+import { preload, SWRConfig } from 'swr'
+import { User } from './user'
+
+const getUser = () => fetchUserFromDatabase()
+
+export default function Page() {
+  const cacheData = preload('/api/user', getUser)
+
+  return (
+    <SWRConfig value={{ cacheData }}>
+      <User />
+    </SWRConfig>
+  )
+}
+```
+
+The client component uses the same key with its usual client-side fetcher:
+
+```tsx filename="app/user.tsx" copy
+'use client'
+
+import useSWR from 'swr'
+
+const fetcher = (url: string) => fetch(url).then(res => res.json())
+
+export function User() {
+  const { data } = useSWR('/api/user', fetcher)
+  return <h1>{data?.name}</h1>
+}
+```
+
+SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+
+Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+
+```tsx
+const cacheData = {
+  ...preload('/api/user', getUser),
+  ...preload('/api/posts', getPosts),
+}
+```
+
+`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
 
 ## Client Side Data Fetching [#client-side-data-fetching]
 

--- a/content/docs/with-nextjs.fr.mdx
+++ b/content/docs/with-nextjs.fr.mdx
@@ -174,7 +174,7 @@ If the page must be pre-rendered, Next.js supports [2 forms of pre-rendering](ht
 
 Together with SWR, you can pre-render the page for SEO, and also have features such as caching, revalidation, focus tracking, refetching on interval on the client side.
 
-You can use the `fallback` option of [`SWRConfig`](/docs/global-configuration) to pass the pre-fetched data as the initial value of all SWR hooks.
+Vous pouvez utiliser l'option `cacheData` de [`SWRConfig`](/docs/global-configuration) pour placer les données récupérées sur le serveur dans le cache de tous les hooks SWR de cette frontière.
 
 For example with `getStaticProps`:
 
@@ -184,7 +184,7 @@ For example with `getStaticProps`:
   const article = await getArticleFromAPI()
   return {
     props: {
-      fallback: {
+      cacheData: {
         '/api/article': article
       }
     }
@@ -192,15 +192,15 @@ For example with `getStaticProps`:
 }
 
 function Article() {
-  // `data` will always be available as it's in `fallback`.
+  // `data` est disponible grâce à `cacheData`, fourni par le serveur.
   const { data } = useSWR('/api/article', fetcher)
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   // SWR hooks inside the `SWRConfig` boundary will use those values.
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )
@@ -210,12 +210,12 @@ export default function Page({ fallback }) {
 The page is still pre-rendered. It's SEO friendly, fast to response, but also fully powered by SWR on the client side. The data can be dynamic and self-updated over time.
 
 <Callout emoji="💡">
-  The `Article` component will render the pre-generated data first, and after the page is hydrated, it will fetch the latest data again to keep it refresh.
+  Le composant `Article` affiche les données prégénérées et les hydrate dans le cache client sans requête initiale en double. Les événements de revalidation ultérieurs utilisent toujours le fetcher client.
 </Callout>
 
 ### Complex Keys [#complex-keys]
 
-`useSWR` can be used with keys that are `array` and `function` types. Utilizing pre-fetched data with these kinds of keys requires serializing the `fallback` keys with `unstable_serialize`.
+`useSWR` accepte des clés de type `array` et `function`. Lorsque vous créez `cacheData` manuellement, sérialisez ces clés avec `unstable_serialize`.
 
 ```jsx
 import useSWR, { unstable_serialize } from 'swr'
@@ -224,7 +224,7 @@ export async function getStaticProps () {
   const article = await getArticleFromAPI(1)
   return {
     props: {
-      fallback: {
+      cacheData: {
         // unstable_serialize() array style key
         [unstable_serialize(['api', 'article', 1])]: article,
       }
@@ -238,9 +238,9 @@ function Article() {
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )

--- a/content/docs/with-nextjs.fr.mdx
+++ b/content/docs/with-nextjs.fr.mdx
@@ -16,7 +16,7 @@ import { unstable_serialize } from 'swr' // ✅ Available in server components
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ Available in server components
 
 import { SWRConfig } from 'swr' // ✅ Available in server components
-import { preload } from 'swr' // ✅ Available in server components
+import { preload } from 'swr' // ✅ Disponible dans les Server Components
 ```
 
 <Callout type="error">
@@ -112,13 +112,13 @@ By passing promises from Server Components to Client Components, the data fetchi
   Pour adopter progressivement ce modèle de préchargement dans votre application, vous pouvez activer l'option `strictServerPrefetchWarning`. Cela affichera un message d'avertissement dans la console lorsqu'une clé n'a pas de données pré-remplies fournies, vous aidant à identifier quels appels de récupération de données pourraient bénéficier d'un préchargement côté serveur.
 </Callout>
 
-### Preload Data into the Client Cache [#preload-data-into-client-cache]
+### Précharger les données dans le cache client [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
-  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+  Cette fonctionnalité nécessite SWR 2.5.0-beta.1 ou une version ultérieure et reste expérimentale.
 </Callout>
 
-In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+Dans un Server Component, `preload(key, fetcher)` lance immédiatement la récupération des données et renvoie un objet `CacheData` limité à la requête. Transmettez cet objet à l'option `cacheData` de `SWRConfig` :
 
 ```tsx filename="app/page.tsx" copy
 import { preload, SWRConfig } from 'swr'
@@ -137,7 +137,7 @@ export default function Page() {
 }
 ```
 
-The client component uses the same key with its usual client-side fetcher:
+Le composant client utilise la même clé avec son fetcher côté client habituel :
 
 ```tsx filename="app/user.tsx" copy
 'use client'
@@ -152,9 +152,9 @@ export function User() {
 }
 ```
 
-SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+SWR utilise le résultat chargé sur le serveur pour le rendu initial, l'écrit dans le cache client pendant l'hydratation et évite une requête initiale en double côté client. Les revalidations suivantes utilisent toujours le fetcher côté client.
 
-Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+Chaque appel à `preload` renvoie un nouvel objet. Fusionnez ces objets pour précharger plusieurs clés sans les attendre :
 
 ```tsx
 const cacheData = {
@@ -163,7 +163,7 @@ const cacheData = {
 }
 ```
 
-`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
+`preload` sérialise automatiquement les clés SWR complexes. L'option `cacheData` est uniquement prise en charge par `SWRConfig` ; elle ne peut pas être transmise directement à `useSWR`.
 
 ## Client Side Data Fetching [#client-side-data-fetching]
 

--- a/content/docs/with-nextjs.fr.mdx
+++ b/content/docs/with-nextjs.fr.mdx
@@ -46,28 +46,19 @@ export default function Page() {
 
 ### Prefetch Data in Server Components
 
-Similar to the [pre-rendering with default data](#pre-rendering-with-default-data) pattern, with React Server Components (RSC) you can go even further.
-
-You can __initiate__ the data prefetching on the server side and pass the __promise__ to client component tree via the `<SWRConfig>` provider's `fallback` option:
+L'approche recommandée dans les React Server Components (RSC) consiste à lancer la récupération avec `preload`, puis à transmettre les données renvoyées à l'arbre des composants clients via l'option `cacheData` de `<SWRConfig>` :
 
 ```tsx filename="app/layout.tsx" copy
-import { SWRConfig } from 'swr'
+import { preload, SWRConfig } from 'swr'
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
-  // Initiate the data fetching on the server side.
-  const userPromise = fetchUserFromAPI()
-  const postsPromise = fetchPostsFromAPI()
+  const cacheData = {
+    ...preload('/api/user', fetchUserFromAPI),
+    ...preload('/api/posts', fetchPostsFromAPI),
+  }
 
   return (
-    <SWRConfig
-      value={{
-        fallback: {
-          // Pass the promises to client components.
-          '/api/user': userPromise,
-          '/api/posts': postsPromise,
-        },
-      }}
-    >
+    <SWRConfig value={{ cacheData }}>
       {children}
     </SWRConfig>
   )
@@ -75,10 +66,10 @@ export default async function Layout({ children }: { children: React.ReactNode }
 ```
 
 <Callout emoji="💡">
-  The two data fetching function calls `fetchUserFromAPI()` and `fetchPostsFromAPI()` will be executed in parallel on the server side because we don't await them immediately.
+  Les deux appels à `preload` lancent immédiatement la récupération des données. Les requêtes s'exécutent donc en parallèle sans être attendues dans le layout.
 </Callout>
 
-In React Server Components, you can pass promises across the `"use client"` boundary, and SWR will resolve them automatically during Server-Side Rendering:
+Dans les React Server Components, les promesses contenues dans `cacheData` peuvent traverser la frontière `"use client"`, et SWR les résout automatiquement pendant le rendu côté serveur :
 
 ```tsx filename="app/page.tsx" copy
 'use client'
@@ -86,7 +77,7 @@ In React Server Components, you can pass promises across the `"use client"` boun
 import useSWR from 'swr'
 
 export default function Page() {
-  // SWR will resolve the promise passed from server components.
+  // SWR résout les données préchargées par le Server Component.
   // Both `user` and `posts` are ready during SSR and client hydration.
   const { data: user } = useSWR('/api/user', fetcher)
   const { data: posts } = useSWR('/api/posts', fetcher)
@@ -104,15 +95,15 @@ export default function Page() {
 }
 ```
 
-Then, on the client-side SWR will take over and keep the behavior as usual.
+SWR utilise le résultat chargé sur le serveur pour le rendu initial. Côté client, il prend ensuite le relais et conserve son comportement habituel de revalidation.
 
-By passing promises from Server Components to Client Components, the data fetching can be initiated as early as possible on the server side. And only the UI boundaries (closest `Suspense` boundary or Next.js layout) that actually consume the data will be blocked during streaming SSR.
+Avec `preload` et `cacheData`, la récupération commence le plus tôt possible sur le serveur. Seules les frontières d'interface qui consomment les données, comme la frontière `Suspense` la plus proche ou le layout Next.js, sont bloquées pendant le streaming SSR.
 
 <Callout type="default">
   Pour adopter progressivement ce modèle de préchargement dans votre application, vous pouvez activer l'option `strictServerPrefetchWarning`. Cela affichera un message d'avertissement dans la console lorsqu'une clé n'a pas de données pré-remplies fournies, vous aidant à identifier quels appels de récupération de données pourraient bénéficier d'un préchargement côté serveur.
 </Callout>
 
-### Précharger les données dans le cache client [#preload-data-into-client-cache]
+### Fonctionnement de `cacheData` [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
   Cette fonctionnalité nécessite SWR 2.5.0-beta.1 ou une version ultérieure et reste expérimentale.

--- a/content/docs/with-nextjs.ja.mdx
+++ b/content/docs/with-nextjs.ja.mdx
@@ -16,6 +16,7 @@ import { unstable_serialize } from 'swr' // ✅ サーバーコンポーネン�
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ サーバーコンポーネントで利用可能
 
 import { SWRConfig } from 'swr' // ✅ サーバーコンポーネントで利用可能
+import { preload } from 'swr' // ✅ Available in server components
 ```
 
 <Callout type="error">
@@ -110,6 +111,59 @@ export default function Page() {
 <Callout type="default">
   アプリケーションでこのプリフェッチパターンを段階的に採用するには、`strictServerPrefetchWarning` オプションを有効にすることができます。これにより、キーに事前入力されたデータが提供されていない場合にコンソールに警告メッセージが表示され、どのデータフェッチ呼び出しがサーバーサイドプリフェッチの恩恵を受けられるかを特定するのに役立ちます。
 </Callout>
+
+### Preload Data into the Client Cache [#preload-data-into-client-cache]
+
+<Callout emoji="🧪">
+  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+</Callout>
+
+In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+
+```tsx filename="app/page.tsx" copy
+import { preload, SWRConfig } from 'swr'
+import { User } from './user'
+
+const getUser = () => fetchUserFromDatabase()
+
+export default function Page() {
+  const cacheData = preload('/api/user', getUser)
+
+  return (
+    <SWRConfig value={{ cacheData }}>
+      <User />
+    </SWRConfig>
+  )
+}
+```
+
+The client component uses the same key with its usual client-side fetcher:
+
+```tsx filename="app/user.tsx" copy
+'use client'
+
+import useSWR from 'swr'
+
+const fetcher = (url: string) => fetch(url).then(res => res.json())
+
+export function User() {
+  const { data } = useSWR('/api/user', fetcher)
+  return <h1>{data?.name}</h1>
+}
+```
+
+SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+
+Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+
+```tsx
+const cacheData = {
+  ...preload('/api/user', getUser),
+  ...preload('/api/posts', getPosts),
+}
+```
+
+`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
 
 ## クライアントサイドでのデータフェッチ [#client-side-data-fetching]
 

--- a/content/docs/with-nextjs.ja.mdx
+++ b/content/docs/with-nextjs.ja.mdx
@@ -174,7 +174,7 @@ const cacheData = {
 
 SWR と組み合わせることで、SEO のためにページをプリレンダリングし、さらにキャッシュ、再検証、フォーカストラッキング、クライアントサイドで行われる一定間隔での再フェッチなどの機能も利用できます。
 
-[`SWRConfig`](/docs/global-configuration) の `fallback` オプションを使用して、事前に取得したデータをすべての SWR フックの初期値として渡すことができます。
+[`SWRConfig`](/docs/global-configuration) の `cacheData` オプションを使用すると、サーバーで取得したデータを境界内のすべての SWR フックのキャッシュに渡せます。
 
 `getStaticProps` の例:
 
@@ -184,7 +184,7 @@ SWR と組み合わせることで、SEO のためにページをプリレンダ
   const article = await getArticleFromAPI()
   return {
     props: {
-      fallback: {
+      cacheData: {
         '/api/article': article
       }
     }
@@ -192,15 +192,15 @@ SWR と組み合わせることで、SEO のためにページをプリレンダ
 }
 
 function Article() {
-  // `data` は `fallback` 内にあるため常に利用可能です
+  // `data` はサーバーから渡された `cacheData` で利用できます
   const { data } = useSWR('/api/article', fetcher)
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   // `SWRConfig` 内の SWR フックはそれらの値を使用します
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )
@@ -210,12 +210,12 @@ export default function Page({ fallback }) {
 このページはプリレンダリングされます。SEO に優れ、迅速に応答しますが、クライアントサイドでは完全に SWR によって駆動されています。データは動的で、時間の経過とともに自動更新されます。
 
 <Callout emoji="💡">
-  `Article` コンポーネントは最初は事前に生成されたデータをレンダリングし、ページがハイドレートされた後、最新のデータを再度フェッチして更新します。
+  `Article` コンポーネントは事前に生成されたデータをレンダリングし、初回リクエストを重複させずにクライアントキャッシュへハイドレーションします。以降の再検証イベントでは引き続きクライアント側の fetcher が使用されます。
 </Callout>
 
 ### 複雑なキー [#complex-keys]
 
-`useSWR` は、`array` 型および `function` 型のキーとともに使用できます。これらの種類のキーで事前にフェッチしたデータを利用するには、`fallback` キーを `unstable_serialize` でシリアライズする必要があります。
+`useSWR` は `array` 型および `function` 型のキーとともに使用できます。`cacheData` を手動で作成する場合は、これらのキーを `unstable_serialize` でシリアライズします。
 
 ```jsx
 import useSWR, { unstable_serialize } from 'swr'
@@ -224,7 +224,7 @@ export async function getStaticProps () {
   const article = await getArticleFromAPI(1)
   return {
     props: {
-      fallback: {
+      cacheData: {
         // unstable_serialize() を使用した配列スタイルのキー
         [unstable_serialize(['api', 'article', 1])]: article,
       }
@@ -238,9 +238,9 @@ function Article() {
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )

--- a/content/docs/with-nextjs.ja.mdx
+++ b/content/docs/with-nextjs.ja.mdx
@@ -46,28 +46,19 @@ export default function Page() {
 
 ### サーバーコンポーネントでデータをプリフェッチする
 
-[デフォルトデータを使ったプリレンダリング](#pre-rendering-with-default-data) パターンと同様に、React Server Components (RSC) を使用すればさらに先へ進むことができます。
-
-サーバーサイドでデータのプリフェッチを __開始__ し、`<SWRConfig>` provider の `fallback` オプションを介してクライアントコンポーネントツリーに __promise__ を渡すことができます:
+React Server Components (RSC) では、`preload` でデータ取得を開始し、返されたデータを `<SWRConfig>` の `cacheData` オプションを通してクライアントコンポーネントツリーに渡す方法を推奨します。
 
 ```tsx filename="app/layout.tsx" copy
-import { SWRConfig } from 'swr'
+import { preload, SWRConfig } from 'swr'
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
-  // サーバーサイドでデータフェッチを開始します
-  const userPromise = fetchUserFromAPI()
-  const postsPromise = fetchPostsFromAPI()
+  const cacheData = {
+    ...preload('/api/user', fetchUserFromAPI),
+    ...preload('/api/posts', fetchPostsFromAPI),
+  }
 
   return (
-    <SWRConfig
-      value={{
-        fallback: {
-          // promise をクライアントコンポーネントに渡します
-          '/api/user': userPromise,
-          '/api/posts': postsPromise,
-        },
-      }}
-    >
+    <SWRConfig value={{ cacheData }}>
       {children}
     </SWRConfig>
   )
@@ -75,10 +66,10 @@ export default async function Layout({ children }: { children: React.ReactNode }
 ```
 
 <Callout emoji="💡">
-  2つのデータ取得関数呼び出し `fetchUserFromAPI()` と `fetchPostsFromAPI()` は、即座に await しないため、サーバーサイドで並列に実行されます。
+  どちらの `preload` 呼び出しも直ちにデータ取得を開始するため、layout 内で await しなくてもリクエストは並列に実行されます。
 </Callout>
 
-React Server Components では、`"use client"` 境界を越えて promise を渡すことができ、SWR はサーバーサイドレンダリング中にそれらを自動的に解決します:
+React Server Components では、`cacheData` 内の promise を `"use client"` 境界を越えて渡すことができ、SWR はサーバーサイドレンダリング中に自動的に解決します。
 
 ```tsx filename="app/page.tsx" copy
 'use client'
@@ -86,7 +77,7 @@ React Server Components では、`"use client"` 境界を越えて promise を�
 import useSWR from 'swr'
 
 export default function Page() {
-  // SWR はサーバーコンポーネントから渡された promise を解決します
+  // SWR は Server Component がプリロードしたデータを解決します
   // SSR とクライアント hydration 中に、`user` と `posts` の両方が準備完了します
   const { data: user } = useSWR('/api/user', fetcher)
   const { data: posts } = useSWR('/api/posts', fetcher)
@@ -104,15 +95,15 @@ export default function Page() {
 }
 ```
 
-その後、クライアントサイドでは SWR が引き継ぎ、通常通りの動作を維持します。
+SWR は初回レンダリングにサーバーで読み込んだ結果を使用します。クライアントでは処理を引き継ぎ、通常の再検証を続けます。
 
-サーバーコンポーネントからクライアントコンポーネントに promise を渡すことで、データフェッチをできるだけ早くサーバーサイドで開始できます。そして、データを実際に使用する UI 境界(最も近い `Suspense` 境界または Next.js layout)のみが、ストリーミング SSR 中にブロックされます。
+`preload` と `cacheData` を使うと、サーバー上で可能な限り早くデータ取得を開始できます。ストリーミング SSR 中にブロックされるのは、最も近い `Suspense` 境界や Next.js layout など、実際にデータを使用する UI 境界だけです。
 
 <Callout type="default">
   アプリケーションでこのプリフェッチパターンを段階的に採用するには、`strictServerPrefetchWarning` オプションを有効にすることができます。これにより、キーに事前入力されたデータが提供されていない場合にコンソールに警告メッセージが表示され、どのデータフェッチ呼び出しがサーバーサイドプリフェッチの恩恵を受けられるかを特定するのに役立ちます。
 </Callout>
 
-### クライアントキャッシュへのデータのプリロード [#preload-data-into-client-cache]
+### `cacheData` の仕組み [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
   この機能を利用するには SWR 2.5.0-beta.1 以降が必要です。現在は実験的な機能です。

--- a/content/docs/with-nextjs.ja.mdx
+++ b/content/docs/with-nextjs.ja.mdx
@@ -16,7 +16,7 @@ import { unstable_serialize } from 'swr' // ✅ サーバーコンポーネン�
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ サーバーコンポーネントで利用可能
 
 import { SWRConfig } from 'swr' // ✅ サーバーコンポーネントで利用可能
-import { preload } from 'swr' // ✅ Available in server components
+import { preload } from 'swr' // ✅ サーバーコンポーネントで利用可能
 ```
 
 <Callout type="error">
@@ -112,13 +112,13 @@ export default function Page() {
   アプリケーションでこのプリフェッチパターンを段階的に採用するには、`strictServerPrefetchWarning` オプションを有効にすることができます。これにより、キーに事前入力されたデータが提供されていない場合にコンソールに警告メッセージが表示され、どのデータフェッチ呼び出しがサーバーサイドプリフェッチの恩恵を受けられるかを特定するのに役立ちます。
 </Callout>
 
-### Preload Data into the Client Cache [#preload-data-into-client-cache]
+### クライアントキャッシュへのデータのプリロード [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
-  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+  この機能を利用するには SWR 2.5.0-beta.1 以降が必要です。現在は実験的な機能です。
 </Callout>
 
-In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+サーバーコンポーネントで `preload(key, fetcher)` を呼び出すと、データ取得が直ちに開始され、リクエストスコープの `CacheData` オブジェクトが返されます。このオブジェクトを `SWRConfig` の `cacheData` オプションに渡します。
 
 ```tsx filename="app/page.tsx" copy
 import { preload, SWRConfig } from 'swr'
@@ -137,7 +137,7 @@ export default function Page() {
 }
 ```
 
-The client component uses the same key with its usual client-side fetcher:
+クライアントコンポーネントでは、同じキーと通常のクライアント側 fetcher を使用します。
 
 ```tsx filename="app/user.tsx" copy
 'use client'
@@ -152,9 +152,9 @@ export function User() {
 }
 ```
 
-SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+SWR は初回レンダリングにサーバーで読み込んだ結果を使用し、ハイドレーション中にクライアントキャッシュへ書き込みます。そのため、初回のクライアントリクエストは重複して実行されません。以降の再検証では引き続きクライアント側の fetcher が使用されます。
 
-Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+`preload` は呼び出すたびに新しいオブジェクトを返します。複数のキーを await せずにプリロードするには、これらのオブジェクトをマージします。
 
 ```tsx
 const cacheData = {
@@ -163,7 +163,7 @@ const cacheData = {
 }
 ```
 
-`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
+`preload` は複雑な SWR キーを自動的にシリアライズします。`cacheData` オプションは `SWRConfig` でのみサポートされており、`useSWR` に直接渡すことはできません。
 
 ## クライアントサイドでのデータフェッチ [#client-side-data-fetching]
 

--- a/content/docs/with-nextjs.ko.mdx
+++ b/content/docs/with-nextjs.ko.mdx
@@ -16,7 +16,7 @@ import { unstable_serialize } from 'swr' // ✅ 서버 컴포넌트에서 사용
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ 서버 컴포넌트에서 사용 가능합니다.
 
 import { SWRConfig } from 'swr' // ✅ 서버 컴포넌트에서 사용 가능합니다.
-import { preload } from 'swr' // ✅ Available in server components
+import { preload } from 'swr' // ✅ 서버 컴포넌트에서 사용 가능
 ```
 
 <Callout type="error">
@@ -112,13 +112,13 @@ export default function Page() {
   애플리케이션에서 이 프리페치 패턴을 점진적으로 채택하려면 `strictServerPrefetchWarning` 옵션을 활성화할 수 있습니다. 이는 키에 미리 채워진 데이터가 제공되지 않은 경우 콘솔에 경고 메시지를 표시하여 어떤 데이터 페칭 호출이 서버 측 프리페칭의 이점을 얻을 수 있는지 식별하는 데 도움을 줍니다.
 </Callout>
 
-### Preload Data into the Client Cache [#preload-data-into-client-cache]
+### 클라이언트 캐시에 데이터 프리로드하기 [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
-  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+  이 기능을 사용하려면 SWR 2.5.0-beta.1 이상이 필요하며, 현재 실험 단계입니다.
 </Callout>
 
-In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+서버 컴포넌트에서 `preload(key, fetcher)`를 호출하면 데이터 가져오기가 즉시 시작되고 요청 범위의 `CacheData` 객체가 반환됩니다. 이 객체를 `SWRConfig`의 `cacheData` 옵션에 전달하세요.
 
 ```tsx filename="app/page.tsx" copy
 import { preload, SWRConfig } from 'swr'
@@ -137,7 +137,7 @@ export default function Page() {
 }
 ```
 
-The client component uses the same key with its usual client-side fetcher:
+클라이언트 컴포넌트에서는 동일한 키와 일반적인 클라이언트 측 fetcher를 사용합니다.
 
 ```tsx filename="app/user.tsx" copy
 'use client'
@@ -152,9 +152,9 @@ export function User() {
 }
 ```
 
-SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+SWR은 초기 렌더링에 서버에서 불러온 결과를 사용하고, hydration 중에 이를 클라이언트 캐시에 기록하며, 중복되는 초기 클라이언트 요청을 건너뜁니다. 이후 재검증에는 계속 클라이언트 측 fetcher가 사용됩니다.
 
-Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+각 `preload` 호출은 새 객체를 반환합니다. 여러 키를 기다리지 않고 프리로드하려면 이 객체들을 병합하세요.
 
 ```tsx
 const cacheData = {
@@ -163,7 +163,7 @@ const cacheData = {
 }
 ```
 
-`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
+`preload`는 복잡한 SWR 키를 자동으로 직렬화합니다. `cacheData` 옵션은 `SWRConfig`에서만 지원되며 `useSWR`에 직접 전달할 수 없습니다.
 
 ## 클라이언트 사이드 데이터 페칭 [#client-side-data-fetching]
 

--- a/content/docs/with-nextjs.ko.mdx
+++ b/content/docs/with-nextjs.ko.mdx
@@ -174,7 +174,7 @@ const cacheData = {
 
 SWR과 함께 사용하면, SEO를 위한 사전 렌더링과 더불어 클라이언트 측 캐싱, 재검증, 포커스 감지, 주기적인 데이터 갱신 같은 기능도 활용할 수 있습니다.
 
-사전 패칭된 데이터를 SWR 훅의 초기 값으로 설정하려면, [`SWRConfig`](/docs/global-configuration)의 `fallback` 옵션을 사용할 수 있습니다.
+[`SWRConfig`](/docs/global-configuration)의 `cacheData` 옵션을 사용하면 서버에서 가져온 데이터를 해당 경계 안의 모든 SWR 훅 캐시에 전달할 수 있습니다.
 
 `getStaticProps`에 대한 예시입니다:
 
@@ -184,7 +184,7 @@ SWR과 함께 사용하면, SEO를 위한 사전 렌더링과 더불어 클라�
   const article = await getArticleFromAPI()
   return {
     props: {
-      fallback: {
+      cacheData: {
         '/api/article': article
       }
     }
@@ -192,15 +192,15 @@ SWR과 함께 사용하면, SEO를 위한 사전 렌더링과 더불어 클라�
 }
 
 function Article() {
-  // `data`는 `fallback`에 있으므로 항상 사용할 수 있습니다.
+  // `data`는 서버가 제공한 `cacheData`에서 사용할 수 있습니다.
   const { data } = useSWR('/api/article', fetcher)
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   // `SWRConfig` 범위 안에 있는 SWR 훅은 해당 값을 사용하게 됩니다.
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )
@@ -216,7 +216,7 @@ The page is still pre-rendered. It's SEO friendly, fast to response, but also fu
 
 ### 복합 키 [#complex-keys]
 
-`useSWR`은 `array` 또는 `function` 형태의 키와 함께 사용할 수 있습니다. 이러한 키를 사용할 때 사전 패칭된 데이터를 적용하려면, `unstable_serialize`을 사용하여 `fallback` 키를 직렬화해야 합니다.
+`useSWR`은 `array` 또는 `function` 형태의 키와 함께 사용할 수 있습니다. `cacheData`를 직접 만들 때는 `unstable_serialize`을 사용해 이러한 키를 직렬화하세요.
 
 ```jsx
 import useSWR, { unstable_serialize } from 'swr'
@@ -225,7 +225,7 @@ export async function getStaticProps () {
   const article = await getArticleFromAPI(1)
   return {
     props: {
-      fallback: {
+      cacheData: {
         // unstable_serialize() 배열 형태의 키
         [unstable_serialize(['api', 'article', 1])]: article,
       }
@@ -239,9 +239,9 @@ function Article() {
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )

--- a/content/docs/with-nextjs.ko.mdx
+++ b/content/docs/with-nextjs.ko.mdx
@@ -46,28 +46,19 @@ export default function Page() {
 
 ### 서버 컴포넌트에서 데이터 프리페치하기
 
-[기본 데이터를 이용한 사전 렌더링](#pre-rendering-with-default-data) 패턴과 유사하게, React Server Components (RSC)를 사용하면 더 나아갈 수 있습니다.
-
-서버 사이드에서 데이터 프리페칭을__시작__하고, `<SWRConfig>` provider의 `fallback` 옵션을 통해 클라이언트 컴포넌트 트리에 __promise__를 전달할 수 있습니다:
+React Server Components (RSC)에서는 `preload`로 데이터 가져오기를 시작하고 반환된 데이터를 `<SWRConfig>`의 `cacheData` 옵션을 통해 클라이언트 컴포넌트 트리에 전달하는 방식을 권장합니다.
 
 ```tsx filename="app/layout.tsx" copy
-import { SWRConfig } from 'swr'
+import { preload, SWRConfig } from 'swr'
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
-  // 서버 사이드에서 데이터 페칭을 시작합니다.
-  const userPromise = fetchUserFromAPI()
-  const postsPromise = fetchPostsFromAPI()
+  const cacheData = {
+    ...preload('/api/user', fetchUserFromAPI),
+    ...preload('/api/posts', fetchPostsFromAPI),
+  }
 
   return (
-    <SWRConfig
-      value={{
-        fallback: {
-          // promise를 클라이언트 컴포넌트에 전달합니다.
-          '/api/user': userPromise,
-          '/api/posts': postsPromise,
-        },
-      }}
-    >
+    <SWRConfig value={{ cacheData }}>
       {children}
     </SWRConfig>
   )
@@ -75,10 +66,10 @@ export default async function Layout({ children }: { children: React.ReactNode }
 ```
 
 <Callout emoji="💡">
-  두 데이터 페칭 함수 호출 `fetchUserFromAPI()` 와 `fetchPostsFromAPI()` 는 즉시 await 하지 않기 때문에 서버 사이드에서 병렬로 실행됩니다.
+  두 `preload` 호출 모두 데이터 가져오기를 즉시 시작하므로 layout에서 기다리지 않아도 요청이 병렬로 실행됩니다.
 </Callout>
 
-React Server Components에서는 `"use client"` 경계를 넘어 promise를 전달할 수 있으며, SWR은 서버 사이드 렌더링 중에 이를 자동으로 해석합니다:
+React Server Components에서는 `cacheData` 안의 promise를 `"use client"` 경계를 넘어 전달할 수 있으며, SWR은 서버 사이드 렌더링 중에 이를 자동으로 해석합니다.
 
 ```tsx filename="app/page.tsx" copy
 'use client'
@@ -86,7 +77,7 @@ React Server Components에서는 `"use client"` 경계를 넘어 promise를 전�
 import useSWR from 'swr'
 
 export default function Page() {
-  // SWR은 서버 컴포넌트에서 전달된 promise를 해석합니다.
+  // SWR은 Server Component가 프리로드한 데이터를 해석합니다.
   // SSR과 클라이언트 hydration 중에 `user`와 `posts` 모두 준비됩니다.
   const { data: user } = useSWR('/api/user', fetcher)
   const { data: posts } = useSWR('/api/posts', fetcher)
@@ -104,15 +95,15 @@ export default function Page() {
 }
 ```
 
-그런 다음 클라이언트 측에서 SWR이 제어권을 가져와 평소처럼 동작을 유지합니다.
+SWR은 초기 렌더링에 서버에서 불러온 결과를 사용합니다. 클라이언트에서는 제어권을 이어받아 일반적인 재검증 동작을 계속합니다.
 
-서버 컴포넌트에서 클라이언트 컴포넌트로 promise를 전달함으로써, 데이터 페칭을 가능한 한 빨리 서버 측에서 시작할 수 있습니다. 그리고 실제로 데이터를 사용하는 UI 경계(가장 가까운 `Suspense` 경계 또는 Next.js layout)만 스트리밍 SSR 중에 차단됩니다.
+`preload`와 `cacheData`를 사용하면 서버에서 가능한 한 빨리 데이터 가져오기를 시작할 수 있습니다. 스트리밍 SSR 중에는 가장 가까운 `Suspense` 경계나 Next.js layout처럼 실제로 데이터를 사용하는 UI 경계만 차단됩니다.
 
 <Callout type="default">
   애플리케이션에서 이 프리페치 패턴을 점진적으로 채택하려면 `strictServerPrefetchWarning` 옵션을 활성화할 수 있습니다. 이는 키에 미리 채워진 데이터가 제공되지 않은 경우 콘솔에 경고 메시지를 표시하여 어떤 데이터 페칭 호출이 서버 측 프리페칭의 이점을 얻을 수 있는지 식별하는 데 도움을 줍니다.
 </Callout>
 
-### 클라이언트 캐시에 데이터 프리로드하기 [#preload-data-into-client-cache]
+### `cacheData`의 동작 방식 [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
   이 기능을 사용하려면 SWR 2.5.0-beta.1 이상이 필요하며, 현재 실험 단계입니다.

--- a/content/docs/with-nextjs.ko.mdx
+++ b/content/docs/with-nextjs.ko.mdx
@@ -16,6 +16,7 @@ import { unstable_serialize } from 'swr' // ✅ 서버 컴포넌트에서 사용
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ 서버 컴포넌트에서 사용 가능합니다.
 
 import { SWRConfig } from 'swr' // ✅ 서버 컴포넌트에서 사용 가능합니다.
+import { preload } from 'swr' // ✅ Available in server components
 ```
 
 <Callout type="error">
@@ -110,6 +111,59 @@ export default function Page() {
 <Callout type="default">
   애플리케이션에서 이 프리페치 패턴을 점진적으로 채택하려면 `strictServerPrefetchWarning` 옵션을 활성화할 수 있습니다. 이는 키에 미리 채워진 데이터가 제공되지 않은 경우 콘솔에 경고 메시지를 표시하여 어떤 데이터 페칭 호출이 서버 측 프리페칭의 이점을 얻을 수 있는지 식별하는 데 도움을 줍니다.
 </Callout>
+
+### Preload Data into the Client Cache [#preload-data-into-client-cache]
+
+<Callout emoji="🧪">
+  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+</Callout>
+
+In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+
+```tsx filename="app/page.tsx" copy
+import { preload, SWRConfig } from 'swr'
+import { User } from './user'
+
+const getUser = () => fetchUserFromDatabase()
+
+export default function Page() {
+  const cacheData = preload('/api/user', getUser)
+
+  return (
+    <SWRConfig value={{ cacheData }}>
+      <User />
+    </SWRConfig>
+  )
+}
+```
+
+The client component uses the same key with its usual client-side fetcher:
+
+```tsx filename="app/user.tsx" copy
+'use client'
+
+import useSWR from 'swr'
+
+const fetcher = (url: string) => fetch(url).then(res => res.json())
+
+export function User() {
+  const { data } = useSWR('/api/user', fetcher)
+  return <h1>{data?.name}</h1>
+}
+```
+
+SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+
+Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+
+```tsx
+const cacheData = {
+  ...preload('/api/user', getUser),
+  ...preload('/api/posts', getPosts),
+}
+```
+
+`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
 
 ## 클라이언트 사이드 데이터 페칭 [#client-side-data-fetching]
 

--- a/content/docs/with-nextjs.mdx
+++ b/content/docs/with-nextjs.mdx
@@ -52,28 +52,19 @@ export default function Page() {
 
 ### Prefetch Data in Server Components
 
-Similar to the [pre-rendering with default data](#pre-rendering-with-default-data) pattern, with React Server Components (RSC) you can go even further.
-
-You can __initiate__ the data prefetching on the server side and pass the __promise__ to client component tree via the `<SWRConfig>` provider's `fallback` option:
+The recommended approach in React Server Components (RSC) is to start fetching with `preload` and pass the returned data to the client component tree through the `cacheData` option of `<SWRConfig>`:
 
 ```tsx filename="app/layout.tsx" copy
-import { SWRConfig } from 'swr'
+import { preload, SWRConfig } from 'swr'
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
-  // Initiate the data fetching on the server side.
-  const userPromise = fetchUserFromAPI()
-  const postsPromise = fetchPostsFromAPI()
+  const cacheData = {
+    ...preload('/api/user', fetchUserFromAPI),
+    ...preload('/api/posts', fetchPostsFromAPI),
+  }
 
   return (
-    <SWRConfig
-      value={{
-        fallback: {
-          // Pass the promises to client components.
-          '/api/user': userPromise,
-          '/api/posts': postsPromise,
-        },
-      }}
-    >
+    <SWRConfig value={{ cacheData }}>
       {children}
     </SWRConfig>
   )
@@ -81,10 +72,10 @@ export default async function Layout({ children }: { children: React.ReactNode }
 ```
 
 <Callout emoji="💡">
-  The two data fetching function calls `fetchUserFromAPI()` and `fetchPostsFromAPI()` will be executed in parallel on the server side because we don't await them immediately.
+  Both `preload` calls start fetching immediately, so the requests run in parallel without being awaited in the layout.
 </Callout>
 
-In React Server Components, you can pass promises across the `"use client"` boundary, and SWR will resolve them automatically during Server-Side Rendering:
+In React Server Components, the promises inside `cacheData` can cross the `"use client"` boundary, and SWR resolves them automatically during Server-Side Rendering:
 
 ```tsx filename="app/page.tsx" copy
 'use client'
@@ -92,7 +83,7 @@ In React Server Components, you can pass promises across the `"use client"` boun
 import useSWR from 'swr'
 
 export default function Page() {
-  // SWR will resolve the promise passed from server components.
+  // SWR resolves the data preloaded by the Server Component.
   // Both `user` and `posts` are ready during SSR and client hydration.
   const { data: user } = useSWR('/api/user', fetcher)
   const { data: posts } = useSWR('/api/posts', fetcher)
@@ -110,15 +101,15 @@ export default function Page() {
 }
 ```
 
-Then, on the client-side SWR will take over and keep the behavior as usual.
+SWR uses the server-loaded result for the initial render. On the client, it takes over and continues with its usual revalidation behavior.
 
-By passing promises from Server Components to Client Components, the data fetching can be initiated as early as possible on the server side. And only the UI boundaries (closest `Suspense` boundary or Next.js layout) that actually consume the data will be blocked during streaming SSR.
+With `preload` and `cacheData`, fetching starts as early as possible on the server. Only the UI boundaries that consume the data, such as the nearest `Suspense` boundary or Next.js layout, are blocked during streaming SSR.
 
 <Callout type="default">
   To incrementally adopt this prefetch pattern in your application, you can enable the `strictServerPrefetchWarning` option. This will show a warning message in the console when a key has no pre-filled data provided, helping you identify which data fetching calls could benefit from server-side prefetching.
 </Callout>
 
-### Preload Data into the Client Cache [#preload-data-into-client-cache]
+### How `cacheData` Works [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
   This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.

--- a/content/docs/with-nextjs.mdx
+++ b/content/docs/with-nextjs.mdx
@@ -180,7 +180,7 @@ If the page must be pre-rendered, Next.js supports [2 forms of pre-rendering](ht
 
 Together with SWR, you can pre-render the page for SEO, and also have features such as caching, revalidation, focus tracking, refetching on interval on the client side.
 
-You can use the `fallback` option of [`SWRConfig`](/docs/global-configuration) to pass the pre-fetched data as the initial value of all SWR hooks.
+You can use the `cacheData` option of [`SWRConfig`](/docs/global-configuration) to pass server-fetched data into the cache for all SWR hooks inside the boundary.
 
 For example with `getStaticProps`:
 
@@ -190,7 +190,7 @@ For example with `getStaticProps`:
   const article = await getArticleFromAPI()
   return {
     props: {
-      fallback: {
+      cacheData: {
         '/api/article': article
       }
     }
@@ -198,15 +198,15 @@ For example with `getStaticProps`:
 }
 
 function Article() {
-  // `data` will always be available as it's in `fallback`.
+  // `data` is available from the server-provided `cacheData`.
   const { data } = useSWR('/api/article', fetcher)
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   // SWR hooks inside the `SWRConfig` boundary will use those values.
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )
@@ -216,12 +216,12 @@ export default function Page({ fallback }) {
 The page is still pre-rendered. It's SEO friendly, fast to response, but also fully powered by SWR on the client side. The data can be dynamic and self-updated over time.
 
 <Callout emoji="💡">
-  The `Article` component will render the pre-generated data first, and after the page is hydrated, it will fetch the latest data again to keep it fresh.
+  The `Article` component renders the pre-generated data and hydrates it into the client cache without a duplicate initial request. Later revalidation events still use the client fetcher.
 </Callout>
 
 ### Complex Keys [#complex-keys]
 
-`useSWR` can be used with keys that are `array` and `function` types. Utilizing pre-fetched data with these kinds of keys requires serializing the `fallback` keys with `unstable_serialize`.
+`useSWR` can be used with keys that are `array` and `function` types. When creating `cacheData` manually, serialize these keys with `unstable_serialize`.
 
 ```jsx
 import useSWR, { unstable_serialize } from 'swr'
@@ -230,7 +230,7 @@ export async function getStaticProps () {
   const article = await getArticleFromAPI(1)
   return {
     props: {
-      fallback: {
+      cacheData: {
         // unstable_serialize() array style key
         [unstable_serialize(['api', 'article', 1])]: article,
       }
@@ -244,9 +244,9 @@ function Article() {
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )

--- a/content/docs/with-nextjs.mdx
+++ b/content/docs/with-nextjs.mdx
@@ -22,6 +22,7 @@ import { unstable_serialize } from 'swr' // ✅ Available in server components
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ Available in server components
 
 import { SWRConfig } from 'swr' // ✅ Available in server components
+import { preload } from 'swr' // ✅ Available in server components
 ```
 
 <Callout type="error">
@@ -116,6 +117,59 @@ By passing promises from Server Components to Client Components, the data fetchi
 <Callout type="default">
   To incrementally adopt this prefetch pattern in your application, you can enable the `strictServerPrefetchWarning` option. This will show a warning message in the console when a key has no pre-filled data provided, helping you identify which data fetching calls could benefit from server-side prefetching.
 </Callout>
+
+### Preload Data into the Client Cache [#preload-data-into-client-cache]
+
+<Callout emoji="🧪">
+  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+</Callout>
+
+In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+
+```tsx filename="app/page.tsx" copy
+import { preload, SWRConfig } from 'swr'
+import { User } from './user'
+
+const getUser = () => fetchUserFromDatabase()
+
+export default function Page() {
+  const cacheData = preload('/api/user', getUser)
+
+  return (
+    <SWRConfig value={{ cacheData }}>
+      <User />
+    </SWRConfig>
+  )
+}
+```
+
+The client component uses the same key with its usual client-side fetcher:
+
+```tsx filename="app/user.tsx" copy
+'use client'
+
+import useSWR from 'swr'
+
+const fetcher = (url: string) => fetch(url).then(res => res.json())
+
+export function User() {
+  const { data } = useSWR('/api/user', fetcher)
+  return <h1>{data?.name}</h1>
+}
+```
+
+SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+
+Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+
+```tsx
+const cacheData = {
+  ...preload('/api/user', getUser),
+  ...preload('/api/posts', getPosts),
+}
+```
+
+`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
 
 ## Client Side Data Fetching [#client-side-data-fetching]
 

--- a/content/docs/with-nextjs.pt.mdx
+++ b/content/docs/with-nextjs.pt.mdx
@@ -46,28 +46,19 @@ export default function Page() {
 
 ### Buscar Dados Antecipadamente em Server Components
 
-Similar ao padrão de [pré-renderização com dados padrão](#pre-rendering-with-default-data), com React Server Components (RSC) você pode ir ainda mais longe.
-
-Você pode __iniciar__ a busca antecipada de dados no lado do servidor e passar a __promise__ para a árvore de componentes do cliente através da opção `fallback` do provider `<SWRConfig>`:
+A abordagem recomendada em React Server Components (RSC) é iniciar a busca com `preload` e passar os dados retornados para a árvore de componentes do cliente por meio da opção `cacheData` do `<SWRConfig>`:
 
 ```tsx filename="app/layout.tsx" copy
-import { SWRConfig } from 'swr'
+import { preload, SWRConfig } from 'swr'
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
-  // Inicie a busca de dados no lado do servidor.
-  const userPromise = fetchUserFromAPI()
-  const postsPromise = fetchPostsFromAPI()
+  const cacheData = {
+    ...preload('/api/user', fetchUserFromAPI),
+    ...preload('/api/posts', fetchPostsFromAPI),
+  }
 
   return (
-    <SWRConfig
-      value={{
-        fallback: {
-          // Passe as promises para os componentes do cliente.
-          '/api/user': userPromise,
-          '/api/posts': postsPromise,
-        },
-      }}
-    >
+    <SWRConfig value={{ cacheData }}>
       {children}
     </SWRConfig>
   )
@@ -75,10 +66,10 @@ export default async function Layout({ children }: { children: React.ReactNode }
 ```
 
 <Callout emoji="💡">
-  As duas chamadas de função de busca de dados `fetchUserFromAPI()` e `fetchPostsFromAPI()` serão executadas em paralelo no lado do servidor porque não as aguardamos imediatamente.
+  As duas chamadas a `preload` iniciam a busca imediatamente, portanto as requisições são executadas em paralelo sem serem aguardadas no layout.
 </Callout>
 
-Em React Server Components, você pode passar promises através da fronteira `"use client"`, e o SWR irá resolvê-las automaticamente durante o Server-Side Rendering:
+Em React Server Components, as promises dentro de `cacheData` podem atravessar a fronteira `"use client"`, e o SWR as resolve automaticamente durante o Server-Side Rendering:
 
 ```tsx filename="app/page.tsx" copy
 'use client'
@@ -86,7 +77,7 @@ Em React Server Components, você pode passar promises através da fronteira `"u
 import useSWR from 'swr'
 
 export default function Page() {
-  // O SWR resolverá a promise passada dos componentes do servidor.
+  // O SWR resolve os dados pré-carregados pelo Server Component.
   // Tanto `user` quanto `posts` estarão prontos durante SSR e hidratação do cliente.
   const { data: user } = useSWR('/api/user', fetcher)
   const { data: posts } = useSWR('/api/posts', fetcher)
@@ -104,15 +95,15 @@ export default function Page() {
 }
 ```
 
-Então, no lado do cliente, o SWR assumirá o controle e manterá o comportamento normal.
+O SWR usa o resultado carregado no servidor para a renderização inicial. No cliente, ele assume o controle e continua com o comportamento normal de revalidação.
 
-Ao passar promises dos Server Components para Client Components, a busca de dados pode ser iniciada o mais cedo possível no lado do servidor. E apenas os limites de UI (fronteira `Suspense` mais próxima ou layout Next.js) que realmente consomem os dados serão bloqueados durante o SSR de streaming.
+Com `preload` e `cacheData`, a busca começa o mais cedo possível no servidor. Apenas os limites de UI que consomem os dados, como a fronteira `Suspense` mais próxima ou o layout do Next.js, são bloqueados durante o SSR de streaming.
 
 <Callout type="default">
   Para adotar incrementalmente este padrão de pré-busca em sua aplicação, você pode habilitar a opção `strictServerPrefetchWarning`. Isso mostrará uma mensagem de aviso no console quando uma chave não tem dados pré-preenchidos fornecidos, ajudando você a identificar quais chamadas de busca de dados poderiam se beneficiar da pré-busca do lado do servidor.
 </Callout>
 
-### Pré-carregar dados no cache do cliente [#preload-data-into-client-cache]
+### Como `cacheData` funciona [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
   Este recurso requer o SWR 2.5.0-beta.1 ou posterior e atualmente é experimental.

--- a/content/docs/with-nextjs.pt.mdx
+++ b/content/docs/with-nextjs.pt.mdx
@@ -175,7 +175,7 @@ Se a página precisa ser pré-renderizada, o Next.js suporta [2 formas de pré-r
 
 Junto com o SWR, você pode pré-renderizar a página para SEO e também ter recursos como cache, revalidação, rastreamento de foco, refetching em intervalo no lado do cliente.
 
-Você pode usar a opção `fallback` de [`SWRConfig`](/docs/global-configuration) para passar os dados pré-buscados como o valor inicial de todos os hooks SWR.
+Você pode usar a opção `cacheData` de [`SWRConfig`](/docs/global-configuration) para colocar os dados obtidos no servidor no cache de todos os hooks SWR dentro desse limite.
 
 Por exemplo, com o `getStaticProps`:
 
@@ -185,7 +185,7 @@ Por exemplo, com o `getStaticProps`:
   const article = await getArticleFromAPI()
   return {
     props: {
-      fallback: {
+      cacheData: {
         '/api/article': article
       }
     }
@@ -193,15 +193,15 @@ Por exemplo, com o `getStaticProps`:
 }
 
 function Article() {
-  // `data` estará sempre disponível, pois está em `fallback`.
+  // `data` está disponível por meio do `cacheData` fornecido pelo servidor.
   const { data } = useSWR('/api/article', fetcher)
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   // Hooks SWR dentro do limites do `SWRConfig` usarão esses valores.
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )
@@ -211,12 +211,12 @@ export default function Page({ fallback }) {
 A página ainda é pré-renderizada. É amigável para SEO, rápida para responder, mas também totalmente alimentada pelo SWR no lado do cliente. Os dados podem ser dinâmicos e atualizados automaticamente ao longo do tempo.
 
 <Callout emoji="💡">
-  O componente `Article` irá renderizar os dados pré-gerados primeiro e, após a página ser hidratada, ele buscará novamente os dados mais recentes para mantê-los atualizados.
+  O componente `Article` renderiza os dados pré-gerados e os hidrata no cache do cliente sem duplicar a requisição inicial. Eventos de revalidação posteriores continuam usando o fetcher do cliente.
 </Callout>
 
 ### Chaves Complexas [#complex-keys]
 
-`useSWR` podem ser usadas com chaves que são do tipo `array` ou `function`. Utilizar dados pré-obtidos com esses tipos de chaves requer serializar as chaves `fallback` usando o `unstable_serialize`.
+`useSWR` pode ser usado com chaves dos tipos `array` e `function`. Ao criar `cacheData` manualmente, serialize essas chaves com `unstable_serialize`.
 
 ```jsx
 import useSWR, { unstable_serialize } from 'swr'
@@ -225,7 +225,7 @@ export async function getStaticProps () {
   const article = await getArticleFromAPI(1)
   return {
     props: {
-      fallback: {
+      cacheData: {
         // chave de lista usando unstable_serialize()
         [unstable_serialize(['api', 'article', 1])]: article,
       }
@@ -239,9 +239,9 @@ function Article() {
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )

--- a/content/docs/with-nextjs.pt.mdx
+++ b/content/docs/with-nextjs.pt.mdx
@@ -16,6 +16,7 @@ import { unstable_serialize } from 'swr' // ✅ Disponível em server components
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ Disponível em server components
 
 import { SWRConfig } from 'swr' // ✅ Disponível em server components
+import { preload } from 'swr' // ✅ Available in server components
 ```
 
 <Callout type="error">
@@ -110,6 +111,59 @@ Ao passar promises dos Server Components para Client Components, a busca de dado
 <Callout type="default">
   Para adotar incrementalmente este padrão de pré-busca em sua aplicação, você pode habilitar a opção `strictServerPrefetchWarning`. Isso mostrará uma mensagem de aviso no console quando uma chave não tem dados pré-preenchidos fornecidos, ajudando você a identificar quais chamadas de busca de dados poderiam se beneficiar da pré-busca do lado do servidor.
 </Callout>
+
+### Preload Data into the Client Cache [#preload-data-into-client-cache]
+
+<Callout emoji="🧪">
+  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+</Callout>
+
+In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+
+```tsx filename="app/page.tsx" copy
+import { preload, SWRConfig } from 'swr'
+import { User } from './user'
+
+const getUser = () => fetchUserFromDatabase()
+
+export default function Page() {
+  const cacheData = preload('/api/user', getUser)
+
+  return (
+    <SWRConfig value={{ cacheData }}>
+      <User />
+    </SWRConfig>
+  )
+}
+```
+
+The client component uses the same key with its usual client-side fetcher:
+
+```tsx filename="app/user.tsx" copy
+'use client'
+
+import useSWR from 'swr'
+
+const fetcher = (url: string) => fetch(url).then(res => res.json())
+
+export function User() {
+  const { data } = useSWR('/api/user', fetcher)
+  return <h1>{data?.name}</h1>
+}
+```
+
+SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+
+Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+
+```tsx
+const cacheData = {
+  ...preload('/api/user', getUser),
+  ...preload('/api/posts', getPosts),
+}
+```
+
+`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
 
 ## Obtendo dados em Client-side [#client-side-data-fetching]
 

--- a/content/docs/with-nextjs.pt.mdx
+++ b/content/docs/with-nextjs.pt.mdx
@@ -16,7 +16,7 @@ import { unstable_serialize } from 'swr' // ✅ Disponível em server components
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ Disponível em server components
 
 import { SWRConfig } from 'swr' // ✅ Disponível em server components
-import { preload } from 'swr' // ✅ Available in server components
+import { preload } from 'swr' // ✅ Disponível em Server Components
 ```
 
 <Callout type="error">
@@ -112,13 +112,13 @@ Ao passar promises dos Server Components para Client Components, a busca de dado
   Para adotar incrementalmente este padrão de pré-busca em sua aplicação, você pode habilitar a opção `strictServerPrefetchWarning`. Isso mostrará uma mensagem de aviso no console quando uma chave não tem dados pré-preenchidos fornecidos, ajudando você a identificar quais chamadas de busca de dados poderiam se beneficiar da pré-busca do lado do servidor.
 </Callout>
 
-### Preload Data into the Client Cache [#preload-data-into-client-cache]
+### Pré-carregar dados no cache do cliente [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
-  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+  Este recurso requer o SWR 2.5.0-beta.1 ou posterior e atualmente é experimental.
 </Callout>
 
-In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+Em um Server Component, `preload(key, fetcher)` inicia a busca imediatamente e retorna um objeto `CacheData` com escopo da requisição. Passe esse objeto para a opção `cacheData` do `SWRConfig`:
 
 ```tsx filename="app/page.tsx" copy
 import { preload, SWRConfig } from 'swr'
@@ -137,7 +137,7 @@ export default function Page() {
 }
 ```
 
-The client component uses the same key with its usual client-side fetcher:
+O componente cliente usa a mesma chave com seu fetcher habitual do lado do cliente:
 
 ```tsx filename="app/user.tsx" copy
 'use client'
@@ -152,9 +152,9 @@ export function User() {
 }
 ```
 
-SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+O SWR usa o resultado carregado no servidor para a renderização inicial, grava-o no cache do cliente durante a hidratação e evita uma requisição inicial duplicada no cliente. As revalidações posteriores continuam usando o fetcher do cliente.
 
-Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+Cada chamada a `preload` retorna um novo objeto. Combine os objetos para pré-carregar várias chaves sem aguardá-las:
 
 ```tsx
 const cacheData = {
@@ -163,7 +163,7 @@ const cacheData = {
 }
 ```
 
-`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
+`preload` serializa automaticamente chaves complexas do SWR. A opção `cacheData` é compatível apenas com `SWRConfig`; ela não pode ser passada diretamente para `useSWR`.
 
 ## Obtendo dados em Client-side [#client-side-data-fetching]
 

--- a/content/docs/with-nextjs.ru.mdx
+++ b/content/docs/with-nextjs.ru.mdx
@@ -174,7 +174,7 @@ const cacheData = {
 
 Совместно с SWR вы можете предварительно отрендерить страницу для SEO, а также использовать функции, такие как кэширование, ревалидация, отслеживание фокуса, повторное получение данных через интервал на стороне клиента.
 
-Вы можете использовать параметр `fallback` в [`SWRConfig`](/docs/global-configuration), чтобы передать предварительно полученные данные в качестве начального значения для всех хуков SWR.
+Вы можете использовать опцию `cacheData` компонента [`SWRConfig`](/docs/global-configuration), чтобы поместить полученные на сервере данные в кеш всех хуков SWR внутри этой границы.
 
 Например, с использованием `getStaticProps`:
 
@@ -184,7 +184,7 @@ const cacheData = {
   const article = await getArticleFromAPI()
   return {
     props: {
-      fallback: {
+      cacheData: {
         '/api/article': article
       }
     }
@@ -192,15 +192,15 @@ const cacheData = {
 }
 
 function Article() {
-  // `data` всегда будет доступна, так как она находится в `fallback`.
+  // `data` доступна из предоставленного сервером `cacheData`.
   const { data } = useSWR('/api/article', fetcher)
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   // Хуки SWR внутри области `SWRConfig` будут использовать эти значения.
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )
@@ -210,12 +210,12 @@ export default function Page({ fallback }) {
 Страница всё ещё предварительно рендерится. Она дружественна к SEO, быстро реагирует, но также полностью поддерживается SWR на стороне клиента. Данные могут быть динамичными и автоматически обновляться со временем.
 
 <Callout emoji="💡">
-  Компонент `Article` сначала отобразит предварительно сгенерированные данные, после гидратации страницы снова запросит последние данные, чтобы обновить их.
+  Компонент `Article` отображает предварительно сгенерированные данные и гидратирует их в клиентский кеш без повторного первоначального запроса. Последующие события ревалидации по-прежнему используют клиентский fetcher.
 </Callout>
 
 ### Комплексные ключи [#complex-keys]
 
-`useSWR` можно использовать с ключами типов `array` и `function`. Для использования предварительно полученных данных с этими типами ключей необходимо сериализовать ключи `fallback` с помощью `unstable_serialize`.
+`useSWR` можно использовать с ключами типов `array` и `function`. При создании `cacheData` вручную сериализуйте эти ключи с помощью `unstable_serialize`.
 
 ```jsx
 import useSWR, { unstable_serialize } from 'swr'
@@ -224,7 +224,7 @@ export async function getStaticProps () {
   const article = await getArticleFromAPI(1)
   return {
     props: {
-      fallback: {
+      cacheData: {
         // ключ в виде массива с использованием unstable_serialize()
         [unstable_serialize(['api', 'article', 1])]: article,
       }
@@ -238,9 +238,9 @@ function Article() {
   return <h1>{data.title}</h1>
 }
 
-export default function Page({ fallback }) {
+export default function Page({ cacheData }) {
   return (
-    <SWRConfig value={{ fallback }}>
+    <SWRConfig value={{ cacheData }}>
       <Article />
     </SWRConfig>
   )

--- a/content/docs/with-nextjs.ru.mdx
+++ b/content/docs/with-nextjs.ru.mdx
@@ -46,28 +46,19 @@ export default function Page() {
 
 ### Предварительная выборка данных в серверных компонентах
 
-Подобно паттерну [предварительного рендеринга с данными по умолчанию](#pre-rendering-with-default-data), с React Server Components (RSC) вы можете пойти ещё дальше.
-
-Вы можете __инициировать__ предварительную выборку данных на стороне сервера и передать __promise__ в дерево клиентских компонентов через опцию `fallback` провайдера `<SWRConfig>`:
+В React Server Components (RSC) рекомендуется начинать получение данных с помощью `preload` и передавать возвращенные данные в дерево клиентских компонентов через опцию `cacheData` компонента `<SWRConfig>`:
 
 ```tsx filename="app/layout.tsx" copy
-import { SWRConfig } from 'swr'
+import { preload, SWRConfig } from 'swr'
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
-  // Инициируйте выборку данных на стороне сервера.
-  const userPromise = fetchUserFromAPI()
-  const postsPromise = fetchPostsFromAPI()
+  const cacheData = {
+    ...preload('/api/user', fetchUserFromAPI),
+    ...preload('/api/posts', fetchPostsFromAPI),
+  }
 
   return (
-    <SWRConfig
-      value={{
-        fallback: {
-          // Передайте promises клиентским компонентам.
-          '/api/user': userPromise,
-          '/api/posts': postsPromise,
-        },
-      }}
-    >
+    <SWRConfig value={{ cacheData }}>
       {children}
     </SWRConfig>
   )
@@ -75,10 +66,10 @@ export default async function Layout({ children }: { children: React.ReactNode }
 ```
 
 <Callout emoji="💡">
-  Два вызова функций выборки данных `fetchUserFromAPI()` и `fetchPostsFromAPI()` будут выполнены параллельно на стороне сервера, потому что мы не ожидаем их немедленно.
+  Оба вызова `preload` немедленно начинают получение данных, поэтому запросы выполняются параллельно без ожидания в layout.
 </Callout>
 
-В React Server Components вы можете передавать promises через границу `"use client"`, и SWR автоматически разрешит их во время рендеринга на стороне сервера:
+В React Server Components promises внутри `cacheData` могут пересекать границу `"use client"`, а SWR автоматически разрешает их во время рендеринга на стороне сервера:
 
 ```tsx filename="app/page.tsx" copy
 'use client'
@@ -86,7 +77,7 @@ export default async function Layout({ children }: { children: React.ReactNode }
 import useSWR from 'swr'
 
 export default function Page() {
-  // SWR разрешит promise, переданный из серверных компонентов.
+  // SWR разрешает данные, предварительно загруженные Server Component.
   // И `user`, и `posts` будут готовы во время SSR и гидратации клиента.
   const { data: user } = useSWR('/api/user', fetcher)
   const { data: posts } = useSWR('/api/posts', fetcher)
@@ -104,15 +95,15 @@ export default function Page() {
 }
 ```
 
-Затем на стороне клиента SWR возьмет на себя управление и сохранит обычное поведение.
+SWR использует загруженный на сервере результат для первоначального рендеринга. На клиенте он берет управление на себя и продолжает обычную ревалидацию.
 
-Передавая promises из серверных компонентов в клиентские компоненты, выборка данных может быть инициирована как можно раньше на стороне сервера. И только границы пользовательского интерфейса (ближайшая граница `Suspense` или layout Next.js), которые фактически используют данные, будут заблокированы во время потокового SSR.
+С `preload` и `cacheData` получение данных начинается на сервере как можно раньше. Во время потокового SSR блокируются только те границы интерфейса, которые используют данные, например ближайшая граница `Suspense` или layout Next.js.
 
 <Callout type="default">
   Чтобы постепенно внедрять этот паттерн предварительной выборки в вашем приложении, вы можете включить опцию `strictServerPrefetchWarning`. Это будет отображать предупреждающее сообщение в консоли, когда для ключа не предоставлены предварительно заполненные данные, помогая вам определить, какие вызовы выборки данных могут выиграть от предварительной выборки на стороне сервера.
 </Callout>
 
-### Предварительная загрузка данных в кеш клиента [#preload-data-into-client-cache]
+### Как работает `cacheData` [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
   Для этой экспериментальной функции требуется SWR 2.5.0-beta.1 или более поздняя версия.

--- a/content/docs/with-nextjs.ru.mdx
+++ b/content/docs/with-nextjs.ru.mdx
@@ -16,6 +16,7 @@ import { unstable_serialize } from 'swr' // ✅ Доступно в сервер
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ Доступно в серверных компонентах
 
 import { SWRConfig } from 'swr' // ✅ Доступно в серверных компонентах
+import { preload } from 'swr' // ✅ Available in server components
 ```
 
 <Callout type="error">
@@ -110,6 +111,59 @@ export default function Page() {
 <Callout type="default">
   Чтобы постепенно внедрять этот паттерн предварительной выборки в вашем приложении, вы можете включить опцию `strictServerPrefetchWarning`. Это будет отображать предупреждающее сообщение в консоли, когда для ключа не предоставлены предварительно заполненные данные, помогая вам определить, какие вызовы выборки данных могут выиграть от предварительной выборки на стороне сервера.
 </Callout>
+
+### Preload Data into the Client Cache [#preload-data-into-client-cache]
+
+<Callout emoji="🧪">
+  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+</Callout>
+
+In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+
+```tsx filename="app/page.tsx" copy
+import { preload, SWRConfig } from 'swr'
+import { User } from './user'
+
+const getUser = () => fetchUserFromDatabase()
+
+export default function Page() {
+  const cacheData = preload('/api/user', getUser)
+
+  return (
+    <SWRConfig value={{ cacheData }}>
+      <User />
+    </SWRConfig>
+  )
+}
+```
+
+The client component uses the same key with its usual client-side fetcher:
+
+```tsx filename="app/user.tsx" copy
+'use client'
+
+import useSWR from 'swr'
+
+const fetcher = (url: string) => fetch(url).then(res => res.json())
+
+export function User() {
+  const { data } = useSWR('/api/user', fetcher)
+  return <h1>{data?.name}</h1>
+}
+```
+
+SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+
+Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+
+```tsx
+const cacheData = {
+  ...preload('/api/user', getUser),
+  ...preload('/api/posts', getPosts),
+}
+```
+
+`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
 
 ## Получение данных на стороне клиента [#client-side-data-fetching]
 

--- a/content/docs/with-nextjs.ru.mdx
+++ b/content/docs/with-nextjs.ru.mdx
@@ -16,7 +16,7 @@ import { unstable_serialize } from 'swr' // ✅ Доступно в сервер
 import { unstable_serialize as infinite_unstable_serialize } from 'swr/infinite' // ✅ Доступно в серверных компонентах
 
 import { SWRConfig } from 'swr' // ✅ Доступно в серверных компонентах
-import { preload } from 'swr' // ✅ Available in server components
+import { preload } from 'swr' // ✅ Доступно в серверных компонентах
 ```
 
 <Callout type="error">
@@ -112,13 +112,13 @@ export default function Page() {
   Чтобы постепенно внедрять этот паттерн предварительной выборки в вашем приложении, вы можете включить опцию `strictServerPrefetchWarning`. Это будет отображать предупреждающее сообщение в консоли, когда для ключа не предоставлены предварительно заполненные данные, помогая вам определить, какие вызовы выборки данных могут выиграть от предварительной выборки на стороне сервера.
 </Callout>
 
-### Preload Data into the Client Cache [#preload-data-into-client-cache]
+### Предварительная загрузка данных в кеш клиента [#preload-data-into-client-cache]
 
 <Callout emoji="🧪">
-  This feature requires SWR 2.5.0-beta.1 or later and is currently experimental.
+  Для этой экспериментальной функции требуется SWR 2.5.0-beta.1 или более поздняя версия.
 </Callout>
 
-In a Server Component, `preload(key, fetcher)` starts the fetch immediately and returns a request-scoped `CacheData` object. Pass that object to the `cacheData` option of `SWRConfig`:
+В серверном компоненте `preload(key, fetcher)` немедленно запускает получение данных и возвращает объект `CacheData`, ограниченный текущим запросом. Передайте этот объект в опцию `cacheData` компонента `SWRConfig`:
 
 ```tsx filename="app/page.tsx" copy
 import { preload, SWRConfig } from 'swr'
@@ -137,7 +137,7 @@ export default function Page() {
 }
 ```
 
-The client component uses the same key with its usual client-side fetcher:
+Клиентский компонент использует тот же ключ и обычный клиентский fetcher:
 
 ```tsx filename="app/user.tsx" copy
 'use client'
@@ -152,9 +152,9 @@ export function User() {
 }
 ```
 
-SWR uses the server-loaded result for the initial render, writes it to the client cache during hydration, and skips the duplicate initial client request. Later revalidations still use the client-side fetcher.
+SWR использует загруженный на сервере результат для первоначального рендеринга, записывает его в клиентский кеш во время гидратации и не выполняет повторный первоначальный запрос с клиента. Последующие ревалидации по-прежнему используют клиентский fetcher.
 
-Each `preload` call returns a new object. Merge the objects to preload multiple keys without awaiting them:
+Каждый вызов `preload` возвращает новый объект. Объедините эти объекты, чтобы предварительно загрузить несколько ключей, не ожидая их выполнения:
 
 ```tsx
 const cacheData = {
@@ -163,7 +163,7 @@ const cacheData = {
 }
 ```
 
-`preload` serializes complex SWR keys automatically. The `cacheData` option is only supported by `SWRConfig`; it cannot be passed directly to `useSWR`.
+`preload` автоматически сериализует сложные ключи SWR. Опция `cacheData` поддерживается только компонентом `SWRConfig`; ее нельзя передать напрямую в `useSWR`.
 
 ## Получение данных на стороне клиента [#client-side-data-fetching]
 


### PR DESCRIPTION
## Summary

- document Server Component preload with SWRConfig cacheData, including hydration, multiple keys, and later client revalidation
- document unload behavior, provider scoping, in-flight result invalidation, and the revalidate option
- expose scoped unload in the global configuration guide
- mirror the new documentation across all localized pages

## Validation

- pnpm exec fumadocs-mdx
- git diff --check
- pnpm build reaches and passes MDX compilation, then stops on the existing out-of-scope mermaid TypeScript error in components/ai-elements/message.tsx:312