### PR TITLE
Redirect the root to the vercel.com/oss/swr lander (307 launch soak)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,16 @@ const config: NextConfig = {
   async redirects() {
     return [
       {
+        // Launch redirect: the SWR marketing lander lives at
+        // vercel.com/oss/swr; the docs stay here. 307 (permanent: false)
+        // during the launch soak, flip to permanent: true (308) once the
+        // lander has settled. Do not merge before the `lander-oss-swr`
+        // flag is live, or the root will bounce visitors into a 404.
+        source: '/',
+        destination: 'https://vercel.com/oss/swr',
+        permanent: false
+      },
+      {
         source: '/docs',
         destination: '/docs/getting-started',
         permanent: true


### PR DESCRIPTION
**HOLD — merge only after the `lander-oss-swr` flag is flipped on vercel.com** (until then this would bounce the root into a 404).

Part of the SWR lander launch: `swr.vercel.app/` redirects to the new marketing page at [vercel.com/oss/swr](https://vercel.com/oss/swr); everything else on this site (docs, blog, examples, all locales) is untouched. The lander's "Get started" CTAs point back at `/docs/getting-started`, so the loop closes.

`permanent: false` → **307** on purpose for the launch soak; a follow-up flips it to `permanent: true` (308) once the lander has settled. Locale roots (`/fr`, `/zh`, …) keep their local landing pages for now — scope is the bare root only.
