### PR TITLE
Nav wordmark: link to getting started, not the redirected root

### DIFF
--- a/components/geistdocs/navbar.tsx
+++ b/components/geistdocs/navbar.tsx
@@ -15,7 +15,10 @@ export const Navbar = () => (
           <SiVercel className="size-5" />
         </a>
         <SlashIcon className="size-5 text-border" />
-        <DynamicLink href="/[lang]">
+        {/* The site root now 307s to the vercel.com/oss/swr lander (#652),
+            so the wordmark deep-links into the docs instead of bouncing
+            visitors off the site they are already on. */}
+        <DynamicLink href="/[lang]/docs/getting-started">
           <Logo />
         </DynamicLink>
       </div>


### PR DESCRIPTION
The root now 307s to the vercel.com/oss/swr lander (#652), so the SWR wordmark in the nav (`href="/[lang]"`) was bouncing readers off the docs they were already on. It now deep-links to `/[lang]/docs/getting-started`, locale-aware.

## Preview

| Check | Link |
|---|---|
| Click the wordmark → getting started | [preview](https://swr-site-git-jmsv-logo-to-getting-started.vercel.sh/docs/getting-started) |

## Details

- Context: [Jiachi's thread](https://vercel.slack.com/archives/C01C07KQTKR/p1786120060508199) — on previews the old link even landed on the SSO page.
- Swept the repo for other `/` links: this was the only one. Footer and menus point at real sections, no `.mdx` links the root, the language selector keeps the current path, and the old landing page's own CTAs already target the docs.
- Left intentionally: non-default locale roots (`/fr`, `/ja`, …) still serve the old landing page — #652 scoped the redirect to the bare root. Happy to extend it to locale roots if that's the direction for the Geistdocs port; your call @huozhi @molebox.
