### PR TITLE
Align OSS wordmark with SWR logo

### DIFF
--- a/app/styles/geistdocs.css
+++ b/app/styles/geistdocs.css
@@ -23,6 +23,12 @@
   }
 }
 
+/* Match the desktop Vercel OSS wordmark height to the SWR mark beside it. */
+header a[href="https://vercel.com/oss"] svg[viewBox="0 0 179 45"] {
+  height: 12px;
+  width: auto;
+}
+
 /* Align docs content with navbar on mobile */
 /*
  * On mobile the sticky MobileDocsBar abuts the navbar via a negative top


### PR DESCRIPTION
## Summary

- reduce the desktop Vercel OSS wordmark to 12px tall
- align it with the adjacent SWR logo without changing the mobile Vercel icon

## Validation

- `pnpm build`: passed
- `git diff --check`: passed
