### PR TITLE
Fix undefined values in the RSS feed

### DIFF
--- a/app/[lang]/rss.xml/route.ts
+++ b/app/[lang]/rss.xml/route.ts
@@ -1,10 +1,10 @@
 import { Feed } from "feed";
 import type { NextRequest } from "next/server";
-import { title } from "@/geistdocs";
+import { agent, title } from "@/geistdocs";
 import { source } from "@/lib/geistdocs/source";
 
 const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
-const baseUrl = `${protocol}://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}`;
+const baseUrl = `${protocol}://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL ?? "swr.vercel.app"}`;
 
 export const revalidate = false;
 
@@ -15,6 +15,7 @@ export const GET = async (
   const { lang } = await params;
   const feed = new Feed({
     title,
+    description: agent.product.description,
     id: baseUrl,
     link: baseUrl,
     language: lang,


### PR DESCRIPTION
### Description

The live RSS feed emits `<description>undefined</description>` because the channel description is omitted from the `Feed` options. Populate it from the existing SWR product description.

Also fall back to `swr.vercel.app` when `NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL` is absent, preventing undefined hostnames in channel and item links outside Vercel deployments.

- [ ] Adding new page
- [x] Updating existing documentation
- [x] Other updates

### Validation

- Confirmed the missing-description problem in the live `https://swr.vercel.app/rss.xml` response.
- TypeScript check passed.
- Requested and parsed all eight localized RSS endpoints with the deployment-domain variable unset: valid XML, expected language and description, valid channel/item hostnames, and no `undefined` values.
